### PR TITLE
Custom adapters and instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,21 @@ axios.get('/user/12345')
   });
 ```
 
+## Custom axios instances
+
+```js
+var defaultConfig = {
+  headers: {
+    "x-api-key": "foobar"
+  }
+};
+
+var apiRequest = require("axios").createAxios(defaultConfig);
+```
+
+This creates a new axios instance with a custom default options. In this
+example it used to create some api service specific http client.
+
 ## Credits
 
 axios is heavily inspired by the [$http service](https://docs.angularjs.org/api/ng/service/$http) provided in [Angular](https://angularjs.org/). Ultimately axios is an effort to provide a standalone `$http`-like service for use outside of Angular.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,12 @@ This is the available config options for making requests. Only the `url` is requ
   xsrfCookieName: 'XSRF-TOKEN', // default
 
   // `xsrfHeaderName` is the name of the http header that carries the xsrf token value
-  xsrfHeaderName: 'X-XSRF-TOKEN' // default
+  xsrfHeaderName: 'X-XSRF-TOKEN', // default
+
+  // `adapter` is a custom adapter function for http implementation. By default
+  // axios uses a xhr adapter in the browser and node.js http module in
+  // node.js. See lib/adapters for examples on how to implement one.
+  adapter: function(resolve, reject, config) { }
 }
 ```
 

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -15,8 +15,12 @@ var axios = module.exports = function axios(config) {
 
   var promise = new Promise(function (resolve, reject) {
     try {
+      // Check for custom adapter first
+      if (typeof config.adapter === "function") {
+        config.adapter(resolve, reject, config);
+      }
       // For browsers use XHR adapter
-      if (typeof window !== 'undefined') {
+      else if (typeof window !== 'undefined') {
         require('./adapters/xhr')(resolve, reject, config);
       }
       // For node use HTTP adapter

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -72,6 +72,9 @@ function createAxios(defaultConfig) {
     // Don't allow overriding defaults.withCredentials
     config.withCredentials = config.withCredentials || defaults.withCredentials;
 
+    // Handle headers separately so individual custom headers can be set
+    config.headers = utils.merge({}, defaultConfig.headers, config.headers);
+
     return axiosCore(config);
   }
 

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -2,17 +2,7 @@ var Promise = require('es6-promise').Promise;
 var defaults = require('./defaults');
 var utils = require('./utils');
 
-var axios = module.exports = function axios(config) {
-  config = utils.merge({
-    method: 'get',
-    headers: {},
-    transformRequest: defaults.transformRequest,
-    transformResponse: defaults.transformResponse
-  }, config);
-
-  // Don't allow overriding defaults.withCredentials
-  config.withCredentials = config.withCredentials || defaults.withCredentials;
-
+function axiosCore(config) {
   var promise = new Promise(function (resolve, reject) {
     try {
       // Check for custom adapter first
@@ -66,40 +56,65 @@ var axios = module.exports = function axios(config) {
   };
 
   return promise;
-};
-
-// Expose defaults
-axios.defaults = defaults;
-
-// Expose all/spread
-axios.all = function (promises) {
-  return Promise.all(promises);
-};
-axios.spread = require('./helpers/spread');
-
-// Provide aliases for supported request methods
-createShortMethods('delete', 'get', 'head');
-createShortMethodsWithData('post', 'put', 'patch');
-
-function createShortMethods() {
-  utils.forEach(arguments, function (method) {
-    axios[method] = function (url, config) {
-      return axios(utils.merge(config || {}, {
-        method: method,
-        url: url
-      }));
-    };
-  });
 }
 
-function createShortMethodsWithData() {
-  utils.forEach(arguments, function (method) {
-    axios[method] = function (url, data, config) {
-      return axios(utils.merge(config || {}, {
-        method: method,
-        url: url,
-        data: data
-      }));
-    };
-  });
+
+function createAxios(defaultConfig) {
+  defaultConfig = defaultConfig || {};
+  function axios(config) {
+    config = utils.merge({
+      method: 'get',
+      headers: {},
+      transformRequest: defaults.transformRequest,
+      transformResponse: defaults.transformResponse
+    }, defaultConfig, config);
+
+    // Don't allow overriding defaults.withCredentials
+    config.withCredentials = config.withCredentials || defaults.withCredentials;
+
+    return axiosCore(config);
+  }
+
+  function createShortMethods() {
+    utils.forEach(arguments, function (method) {
+      axios[method] = function (url, config) {
+        return axios(utils.merge(config || {}, {
+          method: method,
+          url: url
+        }));
+      };
+    });
+  }
+
+  function createShortMethodsWithData() {
+    utils.forEach(arguments, function (method) {
+      axios[method] = function (url, data, config) {
+        return axios(utils.merge(config || {}, {
+          method: method,
+          url: url,
+          data: data
+        }));
+      };
+    });
+  }
+
+  // Expose defaults
+  axios.defaults = defaults;
+
+  // Expose all/spread
+  axios.all = function (promises) {
+    return Promise.all(promises);
+  };
+  axios.spread = require('./helpers/spread');
+
+  // Provide aliases for supported request methods
+  createShortMethods('delete', 'get', 'head');
+  createShortMethodsWithData('post', 'put', 'patch');
+
+  // Expose createAxios for end users too
+  axios.createAxios = createAxios;
+
+  return axios;
 }
+
+module.exports = createAxios();


### PR DESCRIPTION
This pull request is not complete. I'll add tests if you are ok functionality wise with this pull request.

## Motivation for custom adapters

I wanted to test my expressjs based rest service application with axios. In order to test the rest api I need to talk to application instance directly without going through a socket. Easiest way to do this is via [supertest](https://github.com/tj/supertest). The adapter for it is [very simple](https://gist.github.com/epeli/0e1543ca0c2f0f2c27ff).

## Motivation for custom instances

When using this I quickly wanted to have a custom instance of axios with my adapter. I've also figured having an ability to set custom default options for custom instances is very useful in other cases such as creating api specific http clients or presetting csrf tokens etc.

What do you think?