### PR TITLE
Add support for arraybuffer requests in browser

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -36,7 +36,7 @@ module.exports = function xhrAdapter(resolve, reject, config) {
       var headers = parseHeaders(request.getAllResponseHeaders());
       var response = {
         data: transformData(
-          request.responseText,
+          ['text', ''].indexOf(config.responseType || '') !== -1 ? request.responseText : request.response,
           headers,
           config.transformResponse
         ),


### PR DESCRIPTION
As stated in https://github.com/mzabriskie/axios/issues/20#issuecomment-71335775 `responseText` can not be read for arraybuffer requests.

Usage:

```js
axios.get('/path/to/my.pdf', { responseType: 'arraybuffer' }).then(function(resp) {
  var myPdf = new Uint8Array(resp.data); 
});
``` 