### PR TITLE
Fixing arrays in get params

### DIFF
--- a/lib/helpers/buildUrl.js
+++ b/lib/helpers/buildUrl.js
@@ -29,6 +29,11 @@ module.exports = function buildUrl(url, params) {
     if (val === null || typeof val === 'undefined') {
       return;
     }
+
+    if (utils.isArray(val)) {
+      key = key+'[]';
+    }
+
     if (!utils.isArray(val)) {
       val = [val];
     }

--- a/lib/helpers/buildUrl.js
+++ b/lib/helpers/buildUrl.js
@@ -8,7 +8,9 @@ function encode(val) {
     replace(/%3A/gi, ':').
     replace(/%24/g, '$').
     replace(/%2C/gi, ',').
-    replace(/%20/g, '+');
+    replace(/%20/g, '+')
+    replace(/%5B/gi, '[').
+    replace(/%5D/gi, ']');
 }
 
 /**
@@ -31,7 +33,7 @@ module.exports = function buildUrl(url, params) {
     }
 
     if (utils.isArray(val)) {
-      key = key+'[]';
+      key = key + '[]';
     }
 
     if (!utils.isArray(val)) {

--- a/lib/helpers/buildUrl.js
+++ b/lib/helpers/buildUrl.js
@@ -8,7 +8,7 @@ function encode(val) {
     replace(/%3A/gi, ':').
     replace(/%24/g, '$').
     replace(/%2C/gi, ',').
-    replace(/%20/g, '+')
+    replace(/%20/g, '+').
     replace(/%5B/gi, '[').
     replace(/%5D/gi, ']');
 }

--- a/test/specs/helpers/buildUrl.spec.js
+++ b/test/specs/helpers/buildUrl.spec.js
@@ -30,7 +30,7 @@ describe('helpers::buildUrl', function () {
   it('should support array params', function () {
     expect(buildUrl('/foo', {
       foo: ['bar', 'baz']
-    })).toEqual('/foo?foo=bar&foo=baz');
+    })).toEqual('/foo?foo%5B%5D=bar&foo%5B%5D=baz');
   });
 
   it('should support special char params', function () {

--- a/test/specs/helpers/buildUrl.spec.js
+++ b/test/specs/helpers/buildUrl.spec.js
@@ -30,7 +30,7 @@ describe('helpers::buildUrl', function () {
   it('should support array params', function () {
     expect(buildUrl('/foo', {
       foo: ['bar', 'baz']
-    })).toEqual('/foo?foo%5B%5D=bar&foo%5B%5D=baz');
+    })).toEqual('/foo?foo[]=bar&foo[]=baz');
   });
 
   it('should support special char params', function () {


### PR DESCRIPTION
I had an issue sending arrays via GET params to a Rails server. In the current implementation the key in the params does not contain square brackets so that the server doesn’t know that it should handle the incoming params as an array. It only takes the last one.

There already is a test that checks for the implementation without square brackets. Is this defined as a standard somewhere? I researched on some sites and apparently PHP and Ruby’s Rack only support the square bracket notation. As `transformRequest` does only work for `data` and also not for `GET` requests I can’t override this functionality via the axios API. It seems that this has to be handled internally.

I’m proposing to change the current implementation so that square brackets are used for array params in GET requests. What do you think?