### PR TITLE
Adding typescript element to package.json for TSD linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
   },
   "browser": {
     "./lib/adapters/http.js": "./lib/adapters/xhr.js"
+  },
+  "typescript": {
+    "definition": "./axios.d.ts"
   }
 }


### PR DESCRIPTION
Added typescript element to package.json. This change enable us to use axios.d.ts by [tsd](https://github.com/DefinitelyTyped/tsd) link command.  
For more detail about tsd link: https://github.com/DefinitelyTyped/tsd#link-to-bundled-definitions  
