### PR TITLE
In browsers check for XMLHttpRequest, not window

### DIFF
--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -11,7 +11,7 @@ module.exports = function dispatchRequest(config) {
   return new Promise(function (resolve, reject) {
     try {
       // For browsers use XHR adapter
-      if (typeof window !== 'undefined') {
+      if (typeof XMLHttpRequest !== 'undefined') {
         require('../adapters/xhr')(resolve, reject, config);
       }
       // For node use HTTP adapter

--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -11,7 +11,7 @@ module.exports = function dispatchRequest(config) {
   return new Promise(function (resolve, reject) {
     try {
       // For browsers use XHR adapter
-      if (typeof XMLHttpRequest !== 'undefined') {
+      if ((typeof XMLHttpRequest !== 'undefined') || (typeof ActiveXObject !== 'undefined')) {
         require('../adapters/xhr')(resolve, reject, config);
       }
       // For node use HTTP adapter


### PR DESCRIPTION
In nodejs testing environment it's possible to use https://github.com/tmpvar/jsdom library to define a window object, but you still want to use node http adapter. Due to those diverse testing environmnents, I propose to test for XMLHttpRequest directly, because window global object is not a sure sign of a browser environment anymore.