### PR TITLE
Fixing isArrayLike to allow length as a param. Added test

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,6 +131,16 @@ function trim(str) {
 }
 
 /**
+ * Determine if a value is an Arguments object
+ *
+ * @param {Object} val The value to test
+ * @returns {boolean} True if value is an Arguments object, otherwise false
+ */
+function isArguments(val) {
+  return toString.call(val) === '[object Arguments]';
+}
+
+/**
  * Iterate over an Array or an Object invoking a function for each item.
  *
  * If `obj` is an Array or arguments callback will be called passing
@@ -149,7 +159,7 @@ function forEach(obj, fn) {
   }
 
   // Check if obj is array-like
-  var isArrayLike = isArray(obj) || (typeof obj === 'object' && !isNaN(obj.length));
+  var isArrayLike = isArray(obj) || isArguments(obj);
 
   // Force an array if not already something iterable
   if (typeof obj !== 'object' && !isArrayLike) {

--- a/test/specs/helpers/buildUrl.spec.js
+++ b/test/specs/helpers/buildUrl.spec.js
@@ -44,5 +44,13 @@ describe('helpers::buildUrl', function () {
       bar: 'baz'
     })).toEqual('/foo?foo=bar&bar=baz');
   });
+
+  it('should support "length" parameter', function () {
+    expect(buildUrl('/foo', {
+      query: 'bar',
+      start: 0,
+      length: 5
+    })).toEqual('/foo?query=bar&start=0&length=5');
+  });
 });
 


### PR DESCRIPTION
Using length as a test for whether an Object is "[Array-like](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/slice#Array-like_objects)" produces unexpected results.

There may be more objects that need specific checks (other than [object Arguments](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/arguments)). But this passes all existing tests and the new one.