### PR TITLE
Adding 'progress' config option for monitoring uploads and downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ axios.get('/user?ID=12345')
   .catch(function (response) {
     console.log(response);
   });
-	
+
 // Optionally the request above could also be done as
 axios.get('/user', {
     params: {
@@ -147,7 +147,7 @@ This is the available config options for making requests. Only the `url` is requ
   // The last function in the array must return a string or an ArrayBuffer
   transformRequest: [function (data) {
     // Do whatever you want to transform the data
-	
+
     return data;
   }],
 
@@ -155,7 +155,7 @@ This is the available config options for making requests. Only the `url` is requ
   // it is passed to then/catch
   transformResponse: [function (data) {
     // Do whatever you want to transform the data
-	
+
     return data;
   }],
 
@@ -186,7 +186,13 @@ This is the available config options for making requests. Only the `url` is requ
   xsrfCookieName: 'XSRF-TOKEN', // default
 
   // `xsrfHeaderName` is the name of the http header that carries the xsrf token value
-  xsrfHeaderName: 'X-XSRF-TOKEN' // default
+  xsrfHeaderName: 'X-XSRF-TOKEN', // default
+
+  // `progress` allows handling of progress events for 'POST' and 'PUT uploads'
+  // as well as 'GET' downloads
+  progress: function(progressEvent) {
+    // Do whatever you want with the native progress event
+  }
 }
 ```
 
@@ -201,7 +207,7 @@ The response for a request contains the following information.
 
   // `status` is the HTTP status code from the server response
   status: 200,
-  
+
   // `statusText` is the HTTP status message from the server response
   statusText: 'OK',
 

--- a/examples/upload/index.html
+++ b/examples/upload/index.html
@@ -26,7 +26,13 @@
           data.append('foo', 'bar');
           data.append('file', document.getElementById('file').files[0]);
 
-          axios.put('/upload/server', data)
+          var config = {
+            progress: function(progressEvent) {
+              var percentCompleted = progressEvent.loaded / progressEvent.total;
+            }
+          };
+
+          axios.put('/upload/server', data, config)
             .then(function (res) {
               output.className = 'container';
               output.innerHTML = res.data;
@@ -40,4 +46,3 @@
     </script>
   </body>
 </html>
-

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -11,6 +11,7 @@ var transformData = require('./../helpers/transformData');
 var urlIsSameOrigin = require('./../helpers/urlIsSameOrigin');
 
 module.exports = function xhrAdapter(resolve, reject, config) {
+
   // Transform request data
   var data = transformData(
     config.data,
@@ -97,6 +98,15 @@ module.exports = function xhrAdapter(resolve, reject, config) {
       if (request.responseType !== 'json') {
         throw e;
       }
+    }
+  }
+
+  // Handle progress if needed
+  if (config.progress) {
+    if (config.method === 'post' || config.method === 'put') {
+      request.upload.addEventListener('progress', config.progress);
+    } else if (config.method === 'get') {
+      request.addEventListener('progress', config.progress);
     }
   }
 


### PR DESCRIPTION
Addressing [#82](https://github.com/mzabriskie/axios/issues/82).

##### Notes
* This PR does not include any additional test coverage. Curious what your thoughts are there.
* Added a small update to the ```upload``` example code to include this new option.
* ```progress``` vs ```onProgress``` vs (any other name). No opinion or preference here.
* Did not structure the option as an array like ```transformRequest/Response```. There does not seem to be a good default, so no need to merge arrays. However, if consistency is important there, happy to change it.
* First contribution here, happy to conform to any guidelines I may have missed.