### PR TITLE
Adding `xsrf` configuration option to allow for toggling of XSRF protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ axios.get('/user?ID=12345')
   .catch(function (response) {
     console.log(response);
   });
-	
+
 // Optionally the request above could also be done as
 axios.get('/user', {
     params: {
@@ -147,7 +147,7 @@ This is the available config options for making requests. Only the `url` is requ
   // The last function in the array must return a string or an ArrayBuffer
   transformRequest: [function (data) {
     // Do whatever you want to transform the data
-	
+
     return data;
   }],
 
@@ -155,7 +155,7 @@ This is the available config options for making requests. Only the `url` is requ
   // it is passed to then/catch
   transformResponse: [function (data) {
     // Do whatever you want to transform the data
-	
+
     return data;
   }],
 
@@ -182,10 +182,15 @@ This is the available config options for making requests. Only the `url` is requ
   // options are 'arraybuffer', 'blob', 'document', 'json', 'text'
   responseType: 'json', // default
 
-  // `xsrfCookieName` is the name of the cookie to use as a value for xsrf token
+  // `xsrf` indicates whether or not cross-site request forgery protection is enabled
+  xsrf: false, // default
+
+  // `xsrfCookieName` is the name of the cookie to use as a value for xsrf token.
+  // used only when `xsrf` is true
   xsrfCookieName: 'XSRF-TOKEN', // default
 
-  // `xsrfHeaderName` is the name of the http header that carries the xsrf token value
+  // `xsrfHeaderName` is the name of the http header that carries the xsrf token value.
+  // used only when `xsrf` is true
   xsrfHeaderName: 'X-XSRF-TOKEN' // default
 }
 ```
@@ -201,7 +206,7 @@ The response for a request contains the following information.
 
   // `status` is the HTTP status code from the server response
   status: 200,
-  
+
   // `statusText` is the HTTP status message from the server response
   statusText: 'OK',
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ This is the available config options for making requests. Only the `url` is requ
   // options are 'arraybuffer', 'blob', 'document', 'json', 'text'
   responseType: 'json', // default
 
-  // `xsrf` indicates whether or not cross-site request forgery protection is enabled
-  xsrf: false, // default
+  // `xsrfEnabled` indicates whether or not cross-site request forgery protection is enabled
+  xsrfEnabled: true, // default
 
   // `xsrfCookieName` is the name of the cookie to use as a value for xsrf token.
   // used only when `xsrf` is true

--- a/axios.d.ts
+++ b/axios.d.ts
@@ -17,7 +17,7 @@ declare module axios {
     all(iterable: any): axios.Promise;
     spread(callback: any): axios.Promise;
   }
-  
+
   interface Response {
     data?: any;
     status?: number;
@@ -39,6 +39,7 @@ declare module axios {
     data?: any;
     withCredentials?: boolean;
     responseType?: string;
+    xsrf?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
   }

--- a/axios.d.ts
+++ b/axios.d.ts
@@ -39,7 +39,7 @@ declare module axios {
     data?: any;
     withCredentials?: boolean;
     responseType?: string;
-    xsrf?: boolean;
+    xsrfEnabled?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
   }

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -5,10 +5,8 @@
 var defaults = require('./../defaults');
 var utils = require('./../utils');
 var buildUrl = require('./../helpers/buildUrl');
-var cookies = require('./../helpers/cookies');
 var parseHeaders = require('./../helpers/parseHeaders');
 var transformData = require('./../helpers/transformData');
-var urlIsSameOrigin = require('./../helpers/urlIsSameOrigin');
 
 module.exports = function xhrAdapter(resolve, reject, config) {
   // Transform request data
@@ -64,12 +62,17 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     }
   };
 
-  // Add xsrf header
-  var xsrfValue = urlIsSameOrigin(config.url) ?
-      cookies.read(config.xsrfCookieName || defaults.xsrfCookieName) :
-      undefined;
-  if (xsrfValue) {
-    requestHeaders[config.xsrfHeaderName || defaults.xsrfHeaderName] = xsrfValue;
+  if (config.xsrf) {
+    var cookies = require('./../helpers/cookies');
+    var urlIsSameOrigin = require('./../helpers/urlIsSameOrigin');
+
+    // Add xsrf header
+    var xsrfValue = urlIsSameOrigin(config.url) ?
+        cookies.read(config.xsrfCookieName || defaults.xsrfCookieName) :
+        undefined;
+    if (xsrfValue) {
+      requestHeaders[config.xsrfHeaderName || defaults.xsrfHeaderName] = xsrfValue;
+    }
   }
 
   // Add headers to the request

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -62,7 +62,7 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     }
   };
 
-  if (config.xsrf) {
+  if (config.xsrfEnabled) {
     var cookies = require('./../helpers/cookies');
     var urlIsSameOrigin = require('./../helpers/urlIsSameOrigin');
 

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -22,7 +22,7 @@ var axios = module.exports = function axios(config) {
     headers: {},
     transformRequest: defaults.transformRequest,
     transformResponse: defaults.transformResponse,
-    xsrf: false
+    xsrfEnabled: true
   }, config);
 
   // Don't allow overriding defaults.withCredentials

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -21,7 +21,8 @@ var axios = module.exports = function axios(config) {
     method: 'get',
     headers: {},
     transformRequest: defaults.transformRequest,
-    transformResponse: defaults.transformResponse
+    transformResponse: defaults.transformResponse,
+    xsrf: false
   }, config);
 
   // Don't allow overriding defaults.withCredentials

--- a/test/specs/xsrf.spec.js
+++ b/test/specs/xsrf.spec.js
@@ -14,7 +14,8 @@ describe('xsrf', function () {
     var request;
 
     axios({
-      url: '/foo'
+      url: '/foo',
+      xsrf: true
     });
 
     setTimeout(function () {
@@ -30,7 +31,8 @@ describe('xsrf', function () {
     document.cookie = axios.defaults.xsrfCookieName + '=12345';
 
     axios({
-      url: '/foo'
+      url: '/foo',
+      xsrf: true
     });
 
     setTimeout(function () {

--- a/test/specs/xsrf.spec.js
+++ b/test/specs/xsrf.spec.js
@@ -14,8 +14,7 @@ describe('xsrf', function () {
     var request;
 
     axios({
-      url: '/foo',
-      xsrf: true
+      url: '/foo'
     });
 
     setTimeout(function () {
@@ -31,8 +30,7 @@ describe('xsrf', function () {
     document.cookie = axios.defaults.xsrfCookieName + '=12345';
 
     axios({
-      url: '/foo',
-      xsrf: true
+      url: '/foo'
     });
 
     setTimeout(function () {

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -106,7 +106,7 @@ axios({
     },
     withCredentials: false, // default
     responseType: 'json', // default
-    xsrf: false, // default
+    xsrfEnabled: true, // default
     xsrfCookieName: 'XSRF-TOKEN', // default
     xsrfHeaderName: 'X-XSRF-TOKEN' // default
 });

--- a/test/typescript/axios.ts
+++ b/test/typescript/axios.ts
@@ -106,6 +106,7 @@ axios({
     },
     withCredentials: false, // default
     responseType: 'json', // default
+    xsrf: false, // default
     xsrfCookieName: 'XSRF-TOKEN', // default
     xsrfHeaderName: 'X-XSRF-TOKEN' // default
 });


### PR DESCRIPTION
New default is *disabled*. Potentially breaking change for some, but enables axios to work on client-side JS platforms other than the browser (e.g. react-native).