### PR TITLE
FIX typescript definition to correctly type promise callbacks

### DIFF
--- a/axios.d.ts
+++ b/axios.d.ts
@@ -26,8 +26,8 @@ declare module axios {
   }
 
   interface Promise {
-    then(response: axios.Response): axios.Promise;
-    catch(response: axios.Response): axios.Promise;
+    then(onFulfilled:(response: axios.Response) => void): axios.Promise;
+    catch(onRejected:(response: axios.Response) => void): axios.Promise;
   }
 
   interface RequestOptions {


### PR DESCRIPTION
The promise methods take a callback in parameter, not directly an axios.Response

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch