### PR TITLE
return result from callback

### DIFF
--- a/lib/helpers/spread.js
+++ b/lib/helpers/spread.js
@@ -22,6 +22,6 @@
  */
 module.exports = function spread(callback) {
   return function (arr) {
-    callback.apply(null, arr);
+    return callback.apply(null, arr);
   };
 };

--- a/test/specs/helpers/spread.spec.js
+++ b/test/specs/helpers/spread.spec.js
@@ -9,5 +9,13 @@ describe('helpers::spread', function () {
 
     expect(value).toEqual(50);
   });
+
+  it('should return callback result', function () {
+    var value = spread(function (a, b) {
+      return a * b;
+    })([5, 10]);
+
+    expect(value).toEqual(50);
+  });
 });
 

--- a/test/specs/promise.spec.js
+++ b/test/specs/promise.spec.js
@@ -84,15 +84,23 @@ describe('promise', function () {
   it('should support spread', function (done) {
     var sum = 0;
     var fulfilled = false;
+    var result;
 
-    axios.all([123, 456]).then(axios.spread(function (a, b) {
-      sum = a + b;
-      fulfilled = true;
-    }));
+    axios
+      .all([123, 456])
+      .then(axios.spread(function (a, b) {
+        sum = a + b;
+        fulfilled = true;
+        return 'hello world';
+      }))
+      .then(function (res) {
+        result = res;
+      });
 
     setTimeout(function () {
       expect(fulfilled).toEqual(true);
       expect(sum).toEqual(123 + 456);
+      expect(result).toEqual('hello world');
       done();
     }, 0);
   });


### PR DESCRIPTION
Returning the result of the callback allows you to chain the promise like you would expect.

```
function getUserAccount() {
  return axios.get('/user/12345');
}

function getUserPermissions() {
  return axios.get('/user/12345/permissions');
}

axios.all([getUserAccount(), getUserPermissions()])
  .then(axios.spread(function (acct, perms) {
    return doSomethingWithAccount(acct);
  }))
  .then(function (result) {
    // do stuff with result
  });
```