### PR TITLE
Add grunt-cli and phantomjs dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "es6-promise": "^3.0.2",
     "grunt": "^0.4.5",
     "grunt-banner": "^0.5.0",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-nodeunit": "^0.4.1",
     "grunt-contrib-watch": "^0.6.1",
@@ -49,6 +50,7 @@
     "karma-webpack": "^1.7.0",
     "load-grunt-tasks": "^3.2.0",
     "minimist": "^1.1.3",
+    "phantomjs": "^1.9.18",
     "webpack": "^1.11.0",
     "webpack-dev-server": "^1.10.1"
   },


### PR DESCRIPTION
This adds grunt-cli and phantomjs dev deps, to make "npm install" and then "npm run test" work on a fresh clone, since those may not necessarily be installed globally. 