### PR TITLE
Allow Access to Response Buffer

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -65,9 +65,10 @@ module.exports = function httpAdapter(resolve, reject, config) {
     });
 
     res.on('end', function () {
+      var buffer = Buffer.concat(responseBuffer);
       var response = {
         data: transformData(
-          Buffer.concat(responseBuffer).toString('utf8'),
+          config.buffer ? buffer : buffer.toString('utf8'),
           res.headers,
           config.transformResponse
         ),


### PR DESCRIPTION
Now it is possible to:

```
axios.get('http://site.com/image.jpg', {buffer: true}).then(function(res) {
    fs.writeFile('image.jpg', res.data);
});
```

Maintains compatibility with transformResponse:

```
axios.get(
    'http://site.com/image.jpg',
    {
        buffer: true,
        transformResponse: [function(data) {
            return data.slice(0, data.length / 2);
        }]
    }
).then(function(res) {
    fs.writeFile('image.jpg', res.data);
});
```

I had some issues with getting `jasmine.Ajax.requests` to respond properly, but if you're amenable to this PR, I'll take another crack at writing a test.