### PR TITLE
Add support third-party library to serialize url params

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ This is the available config options for making requests. Only the `url` is requ
     ID: 12345
   },
 
+  // `paramsSerializer` is an optional function in charge of serializing `params`
+  // (e.g. https://www.npmjs.com/package/qs, http://api.jquery.com/jquery.param/)
+  paramsSerializer: function(params) {
+    return Qs.stringify(params, {arrayFormat: 'brackets'})
+  },
+
   // `data` is the data to be sent as the request body
   // Only applicable for request methods 'PUT', 'POST', and 'PATCH'
   // When no `transformRequest` is set, must be a string, an ArrayBuffer or a hash

--- a/axios.d.ts
+++ b/axios.d.ts
@@ -41,6 +41,7 @@ declare module axios {
     responseType?: string;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
+    paramsSerializer?: (params: any) => string;
   }
 }
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['jasmine-ajax', 'jasmine'],
+    frameworks: ['jasmine-ajax', 'jasmine', 'sinon'],
 
 
     // list of files / patterns to load in the browser
@@ -52,7 +52,7 @@ module.exports = function(config) {
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
     reporters: ['dots', 'coverage'],
 
-    
+
     coverageReporter: {
       type: 'lcov',
       dir: 'coverage/',

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -29,7 +29,7 @@ module.exports = function xhrAdapter(resolve, reject, config) {
 
   // Create the request
   var request = new (XMLHttpRequest || ActiveXObject)('Microsoft.XMLHTTP');
-  request.open(config.method.toUpperCase(), buildUrl(config.url, config.params), true);
+  request.open(config.method.toUpperCase(), buildUrl(config.url, config.params, config.paramsSerializer), true);
 
   // Set the request timeout in MS
   request.timeout = config.timeout;

--- a/lib/helpers/buildUrl.js
+++ b/lib/helpers/buildUrl.js
@@ -20,39 +20,47 @@ function encode(val) {
  * @param {object} [params] The params to be appended
  * @returns {string} The formatted url
  */
-module.exports = function buildUrl(url, params) {
+module.exports = function buildUrl(url, params, paramsSerializer) {
   if (!params) {
     return url;
   }
 
-  var parts = [];
+  var serializedParams;
+  if (paramsSerializer) {
+    serializedParams = paramsSerializer(params);
+  }
+  else {
+    var parts = [];
 
-  utils.forEach(params, function (val, key) {
-    if (val === null || typeof val === 'undefined') {
-      return;
-    }
-
-    if (utils.isArray(val)) {
-      key = key + '[]';
-    }
-
-    if (!utils.isArray(val)) {
-      val = [val];
-    }
-
-    utils.forEach(val, function (v) {
-      if (utils.isDate(v)) {
-        v = v.toISOString();
+    utils.forEach(params, function (val, key) {
+      if (val === null || typeof val === 'undefined') {
+        return;
       }
-      else if (utils.isObject(v)) {
-        v = JSON.stringify(v);
+
+      if (utils.isArray(val)) {
+        key = key + '[]';
       }
-      parts.push(encode(key) + '=' + encode(v));
+
+      if (!utils.isArray(val)) {
+        val = [val];
+      }
+
+      utils.forEach(val, function (v) {
+        if (utils.isDate(v)) {
+          v = v.toISOString();
+        }
+        else if (utils.isObject(v)) {
+          v = JSON.stringify(v);
+        }
+        parts.push(encode(key) + '=' + encode(v));
+      });
     });
-  });
 
-  if (parts.length > 0) {
-    url += (url.indexOf('?') === -1 ? '?' : '&') + parts.join('&');
+    serializedParams = parts.join('&');
+  }
+
+  if (serializedParams) {
+    url += (url.indexOf('?') === -1 ? '?' : '&') + serializedParams;
   }
 
   return url;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "karma-jasmine": "0.3.6",
     "karma-jasmine-ajax": "0.1.13",
     "karma-phantomjs-launcher": "0.2.1",
+    "karma-sinon": "1.0.4",
     "karma-sourcemap-loader": "0.3.5",
     "karma-webpack": "1.7.0",
     "load-grunt-tasks": "3.3.0",

--- a/test/specs/helpers/buildUrl.spec.js
+++ b/test/specs/helpers/buildUrl.spec.js
@@ -52,5 +52,14 @@ describe('helpers::buildUrl', function () {
       length: 5
     })).toEqual('/foo?query=bar&start=0&length=5');
   });
+
+  it('should use serializer if provided', function () {
+    serializer = sinon.stub();
+    params = {foo: 'bar'};
+    serializer.returns('foo=bar');
+    expect(buildUrl('/foo', params, serializer)).toEqual('/foo?foo=bar');
+    expect(serializer.calledOnce).toBe(true);
+    expect(serializer.calledWith(params)).toBe(true);
+  })
 });
 


### PR DESCRIPTION
Because servers don't parse url params the same way, an optional third-party could be use. To do so, `paramsSerializer` can be provided in the configuration. It's a function which takes `params` as arguments and returns encoding `params`.

This pull request is related to #101.