### PR TITLE
Don't use utils.forEach to loop over arguments

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -71,40 +71,31 @@ axios.spread = require('./helpers/spread');
 // Expose interceptors
 axios.interceptors = defaultInstance.interceptors;
 
-// Provide aliases for supported request methods
-(function () {
-  function createShortMethods() {
-    utils.forEach(arguments, function (method) {
-      Axios.prototype[method] = function (url, config) {
-        return this.request(utils.merge(config || {}, {
-          method: method,
-          url: url
-        }));
-      };
-      axios[method] = bind(Axios.prototype[method], defaultInstance);
-    });
-  }
-
-  function createShortMethodsWithData() {
-    utils.forEach(arguments, function (method) {
-      Axios.prototype[method] = function (url, data, config) {
-        return this.request(utils.merge(config || {}, {
-          method: method,
-          url: url,
-          data: data
-        }));
-      };
-      axios[method] = bind(Axios.prototype[method], defaultInstance);
-    });
-  }
-
-  createShortMethods('delete', 'get', 'head');
-  createShortMethodsWithData('post', 'put', 'patch');
-})();
-
 // Helpers
 function bind (fn, thisArg) {
   return function () {
     return fn.apply(thisArg, Array.prototype.slice.call(arguments));
   };
 }
+
+// Provide aliases for supported request methods
+utils.forEach(['delete', 'get', 'head'], function (method) {
+  Axios.prototype[method] = function (url, config) {
+    return this.request(utils.merge(config || {}, {
+      method: method,
+      url: url
+    }));
+  };
+  axios[method] = bind(Axios.prototype[method], defaultInstance);
+});
+
+utils.forEach(['post', 'put', 'patch'], function (method) {
+  Axios.prototype[method] = function (url, data, config) {
+    return this.request(utils.merge(config || {}, {
+      method: method,
+      url: url,
+      data: data
+    }));
+  };
+  axios[method] = bind(Axios.prototype[method], defaultInstance);
+});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,16 +131,6 @@ function trim(str) {
 }
 
 /**
- * Determine if a value is an Arguments object
- *
- * @param {Object} val The value to test
- * @returns {boolean} True if value is an Arguments object, otherwise false
- */
-function isArguments(val) {
-  return toString.call(val) === '[object Arguments]';
-}
-
-/**
  * Determine if we're running in a standard browser environment
  *
  * This allows axios to run in a web worker, and react-native.
@@ -151,7 +141,7 @@ function isArguments(val) {
  *  typeof document -> undefined
  *
  * react-native:
- *  typeof document.createelement -> undefined
+ *  typeof document.createElement -> undefined
  */
 function isStandardBrowserEnv() {
   return (
@@ -164,7 +154,7 @@ function isStandardBrowserEnv() {
 /**
  * Iterate over an Array or an Object invoking a function for each item.
  *
- * If `obj` is an Array or arguments callback will be called passing
+ * If `obj` is an Array callback will be called passing
  * the value, index, and complete array for each item.
  *
  * If 'obj' is an Object callback will be called passing
@@ -179,16 +169,13 @@ function forEach(obj, fn) {
     return;
   }
 
-  // Check if obj is array-like
-  var isArrayLike = isArray(obj) || isArguments(obj);
-
   // Force an array if not already something iterable
-  if (typeof obj !== 'object' && !isArrayLike) {
+  if (typeof obj !== 'object' && !isArray(obj)) {
     obj = [obj];
   }
 
   // Iterate over array values
-  if (isArrayLike) {
+  if (isArray(obj)) {
     for (var i = 0, l = obj.length; i < l; i++) {
       fn.call(null, obj[i], i, obj);
     }
@@ -222,11 +209,11 @@ function forEach(obj, fn) {
  */
 function merge(/*obj1, obj2, obj3, ...*/) {
   var result = {};
-  forEach(arguments, function (obj) {
-    forEach(obj, function (val, key) {
-      result[key] = val;
-    });
-  });
+  var assignValue = function (val, key) { result[key] = val; };
+  var length = arguments.length;
+  for (var i = 0; i < length; i++) {
+    forEach(arguments[i], assignValue);
+  }
   return result;
 }
 

--- a/test/specs/utils/forEach.spec.js
+++ b/test/specs/utils/forEach.spec.js
@@ -11,18 +11,6 @@ describe('utils::forEach', function () {
     expect(sum).toEqual(15);
   });
 
-  it('should loop over arguments', function () {
-    var sum = 0;
-
-    (function () {
-      forEach(arguments, function (val) {
-        sum += val;
-      });
-    })(1, 2, 3, 4, 5);
-
-    expect(sum).toEqual(15);
-  });
-
   it('should loop over object keys', function () {
     var keys = '';
     var vals = 0;
@@ -61,4 +49,3 @@ describe('utils::forEach', function () {
     expect(count).toEqual(1);
   });
 });
-


### PR DESCRIPTION
Since #91 IE8 support has been broken.
This fixes it by not using utils.forEach to loop over `arguments` (since in IE8 you can't reliably detect if a variable is an arguments object).