### PR TITLE
fixing http adapter WRT `responseType === 'arraybuffer'`

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -65,9 +65,13 @@ module.exports = function httpAdapter(resolve, reject, config) {
     });
 
     res.on('end', function () {
+      var data = Buffer.concat(responseBuffer);
+      if (config.responseType !== 'arraybuffer') {
+        data = data.toString('utf8');
+      }
       var response = {
         data: transformData(
-          Buffer.concat(responseBuffer).toString('utf8'),
+          data,
           res.headers,
           config.transformResponse
         ),


### PR DESCRIPTION
fixing http adapter: return a `Buffer` instead of a `String` in case of `responseType === 'arraybuffer'`