### PR TITLE
HTTP basic authentication.

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -45,6 +45,14 @@ module.exports = function httpAdapter(resolve, reject, config) {
     headers['Content-Length'] = data.length;
   }
 
+  // HTTP basic authentication
+  var auth = undefined;
+  if (config.auth) {
+    var username = config.auth.user || config.auth.username;
+    var password = config.auth.pass || config.auth.password;
+    auth = username + ':' + password;
+  }
+
   // Parse url
   var parsed = url.parse(config.url);
   var options = {
@@ -53,7 +61,8 @@ module.exports = function httpAdapter(resolve, reject, config) {
     path: buildUrl(parsed.path, config.params).replace(/^\?/, ''),
     method: config.method,
     headers: headers,
-    agent: config.agent
+    agent: config.agent,
+    auth: auth
   };
 
   // Create the request

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -27,9 +27,16 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     delete requestHeaders['Content-Type']; // Let the browser set it
   }
 
+  // HTTP basic authentication
+  var configAuth = config.auth || {};
+  var auth = {
+    username: configAuth.username || configAuth.user || '',
+    password: configAuth.password || configAuth.pass || ''
+  };
+
   // Create the request
   var request = new (XMLHttpRequest || ActiveXObject)('Microsoft.XMLHTTP');
-  request.open(config.method.toUpperCase(), buildUrl(config.url, config.params), true);
+  request.open(config.method.toUpperCase(), buildUrl(config.url, config.params), true, auth.username, auth.password);
 
   // Set the request timeout in MS
   request.timeout = config.timeout;


### PR DESCRIPTION
Fixes #78.

I have not yet added any documentation/tests/etc, since I'd like to make sure you're happy with the approach.

I modelled the interface on [`request`'s basic auth](https://github.com/request/request#http-authentication), ie. adding an `auth` key to the config object, which can contain any combination of `user`/`username` and `pass`/`password`.

Thanks for creating axios, the codebase is very pleasant :)