### PR TITLE
Don't include a process shim in the build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,9 @@ function generateConfig(name) {
       library: 'axios',
       libraryTarget: 'umd'
     },
+    node: {
+      process: false
+    },
     externals: [
       {
         './adapters/http': 'var undefined'


### PR DESCRIPTION
The final build of axios contains an unused process shim. This happens by Webpack, since it detects [use of process](https://github.com/mzabriskie/axios/blob/master/lib/core/dispatchRequest.js#L18), and then will include the shim.  Saves about 1kb of the minified build!