### PR TITLE
Don't call slice on arguments

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -105,6 +105,10 @@ axios.interceptors = defaultInstance.interceptors;
 // Helpers
 function bind (fn, thisArg) {
   return function () {
-    return fn.apply(thisArg, Array.prototype.slice.call(arguments));
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; i++) {
+      args[i] = arguments[i];
+    }
+    return fn.apply(thisArg, args);
   };
 }


### PR DESCRIPTION
Calling slice on arguments can prevent optimizations in some JS engines
(see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments).