### PR TITLE
fix(http): unzip data when `encoding-type === gzip`

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -9,6 +9,7 @@ var https = require('https');
 var url = require('url');
 var pkg = require('./../../package.json');
 var Buffer = require('buffer').Buffer;
+var zlib = require('zlib');
 
 module.exports = function httpAdapter(resolve, reject, config) {
   // Transform request data
@@ -66,6 +67,9 @@ module.exports = function httpAdapter(resolve, reject, config) {
 
     res.on('end', function () {
       var data = Buffer.concat(responseBuffer);
+      if (res.headers['content-encoding'] === 'gzip') {
+        data = zlib.unzipSync(data);
+      }
       if (config.responseType !== 'arraybuffer') {
         data = data.toString('utf8');
       }


### PR DESCRIPTION
Gzipped data won't be unzip on server requests, I couldn't achieve that into an interceptor since data will always be string in interceptors.