### PR TITLE
Adding transparent decompression if `content-encoding` is set

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -7,6 +7,7 @@ var transformData = require('./../helpers/transformData');
 var http = require('http');
 var https = require('https');
 var url = require('url');
+var zlib = require('zlib');
 var pkg = require('./../../package.json');
 var Buffer = require('buffer').Buffer;
 
@@ -59,12 +60,27 @@ module.exports = function httpAdapter(resolve, reject, config) {
   // Create the request
   var transport = parsed.protocol === 'https:' ? https : http;
   var req = transport.request(options, function (res) {
+
+    // uncompress the response body transparently if required
+    var stream = res;
+    switch(res.headers['content-encoding']) {
+      case 'gzip':
+      case 'compress':
+      case 'deflate': {
+        // add the unzipper to the body stream processing pipeline
+        stream = stream.pipe(zlib.createUnzip());
+
+        // remove the content-encoding in order to not confuse downstream operations
+        delete res.headers['content-encoding'];
+      }
+    }
+
     var responseBuffer = [];
-    res.on('data', function (chunk) {
+    stream.on('data', function (chunk) {
       responseBuffer.push(chunk);
     });
 
-    res.on('end', function () {
+    stream.on('end', function () {
       var data = Buffer.concat(responseBuffer);
       if (config.responseType !== 'arraybuffer') {
         data = data.toString('utf8');

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1,5 +1,6 @@
 var axios = require('../../../index');
 var http = require('http');
+var zlib = require('zlib');
 var server;
 
 module.exports = {
@@ -24,6 +25,29 @@ module.exports = {
         test.deepEqual(res.data, data);
         test.done();
       });
+    });
+  },
+
+  testTransparentGunzip: function (test) {
+    var data = {
+      firstName: 'Fred',
+      lastName: 'Flintstone',
+      emailAddr: 'fred@example.com'
+    };
+
+    zlib.gzip(JSON.stringify(data), function(err, zipped) {
+
+      server = http.createServer(function (req, res) {
+        res.setHeader('Content-Type', 'application/json;charset=utf-8');
+        res.setHeader('Content-Encoding', 'gzip');
+        res.end(zipped);
+      }).listen(4444, function () {
+        axios.get('http://localhost:4444/').then(function (res) {
+          test.deepEqual(res.data, data);
+          test.done();
+        });
+      });
+
     });
   },
 


### PR DESCRIPTION
This PR adds transparent decompression of content to the `nodejs` implementation if the `content-encoding` header is set.

This is done by the `browser` automatically, and now also in case of the `nodejs` implementation.

A corresponding test case has been added.