### PR TITLE
Adding native 'typings'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,60 @@
+// Type definitions for Axios v0.7.0
+// Project: https://github.com/mzabriskie/axios
+
+declare var axios: axios.AxiosStatic
+
+declare module axios {
+  interface AxiosRequestMethods {
+    get(url: string, config?: any): axios.Promise;
+    delete(url: string, config?: any): axios.Promise;
+    head(url: string, config?: any): axios.Promise;
+    post(url: string, data: any, config?: any): axios.Promise;
+    put(url: string, data: any, config?: any): axios.Promise;
+    patch(url: string, data: any, config?: any): axios.Promise;
+  }
+
+  interface AxiosStatic extends AxiosRequestMethods {
+    (options: axios.RequestOptions): axios.Promise;
+    create(defaultOptions?: axios.InstanceOptions): AxiosInstance;
+    all(iterable: any): axios.Promise;
+    spread(callback: any): axios.Promise;
+  }
+
+  interface AxiosInstance extends AxiosRequestMethods  {
+    request(options: axios.RequestOptions): axios.Promise;
+  }
+
+  interface Response {
+    data?: any;
+    status?: number;
+    statusText?: string;
+    headers?: any;
+    config?: any;
+  }
+
+  interface Promise {
+    then(onFulfilled:(response: axios.Response) => void): axios.Promise;
+    catch(onRejected:(response: axios.Response) => void): axios.Promise;
+  }
+
+  interface InstanceOptions {
+    transformRequest?: (data: any) => any;
+    transformResponse?: (data: any) => any;
+    headers?: any;
+    timeout?: number;
+    withCredentials?: boolean;
+    responseType?: string;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+    paramsSerializer?: (params: any) => string;
+  }
+
+  interface RequestOptions extends InstanceOptions {
+    url: string;
+    method?: string;
+    params?: any;
+    data?: any;
+  }
+}
+
+export = axios;

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "browser": {
     "./lib/adapters/http.js": "./lib/adapters/xhr.js"
   },
+  "typings": "./index.d.ts",
   "typescript": {
     "definition": "./axios.d.ts"
   }


### PR DESCRIPTION
The (relatively new) way of handling type declarations in the TypeScript compiler
is [documented here](https://github.com/Microsoft/TypeScript/wiki/Typings-for-npm-packages).

This pull request simply adds support for 'typings' so that users can seamlessly import
the 'axios' module without the need to add an explicit declarations file to their
tsconfig.json file.