### PR TITLE
Use Typescript 1.6 style to identify typings file

### DIFF
--- a/axios.d.ts
+++ b/axios.d.ts
@@ -1,64 +1,60 @@
 // Type definitions for Axios v0.7.0
 // Project: https://github.com/mzabriskie/axios
 
+import {Promise} from 'es6-promise'
 
-
-declare var axios: axios.AxiosStatic
-
-declare module axios {
-  interface AxiosRequestMethods {
-    get(url: string, config?: any): axios.Promise;
-    delete(url: string, config?: any): axios.Promise;
-    head(url: string, config?: any): axios.Promise;
-    post(url: string, data: any, config?: any): axios.Promise;
-    put(url: string, data: any, config?: any): axios.Promise;
-    patch(url: string, data: any, config?: any): axios.Promise;
-  }
-
-  interface AxiosStatic extends AxiosRequestMethods {
-    (options: axios.RequestOptions): axios.Promise;
-    create(defaultOptions?: axios.InstanceOptions): AxiosInstance;
-    all(iterable: any): axios.Promise;
-    spread(callback: any): axios.Promise;
-  }
-
-  interface AxiosInstance extends AxiosRequestMethods  {
-    request(options: axios.RequestOptions): axios.Promise;
-  }
-
-  interface Response {
-    data?: any;
-    status?: number;
-    statusText?: string;
-    headers?: any;
-    config?: any;
-  }
-
-  interface Promise {
-    then(onFulfilled:(response: axios.Response) => void): axios.Promise;
-    catch(onRejected:(response: axios.Response) => void): axios.Promise;
-  }
-
-  interface InstanceOptions {
-    transformRequest?: (data: any) => any;
-    transformResponse?: (data: any) => any;
-    headers?: any;
-    timeout?: number;
-    withCredentials?: boolean;
-    responseType?: string;
-    xsrfCookieName?: string;
-    xsrfHeaderName?: string;
-    paramsSerializer?: (params: any) => string;
-  }
-
-  interface RequestOptions extends InstanceOptions {
-    url: string;
-    method?: string;
-    params?: any;
-    data?: any;
-  }
+interface AxiosRequestMethods {
+  get(url: string, config?: SpecificRequestOptions): Promise<Response>;
+  delete(url: string, config?: SpecificRequestOptions): Promise<Response>;
+  head(url: string, config?: SpecificRequestOptions): Promise<Response>;
+  post(url: string, data: any, config?: SpecificRequestOptions): Promise<Response>;
+  put(url: string, data: any, config?: SpecificRequestOptions): Promise<Response>;
+  patch(url: string, data: any, config?: SpecificRequestOptions): Promise<Response>;
 }
 
-declare module "axios" {
-  export = axios;
+export interface AxiosInstance extends AxiosRequestMethods  {
+  request(options: RequestOptions): Promise<Response>;
 }
+
+interface Response {
+  data?: any;
+  status?: number;
+  statusText?: string;
+  headers?: any;
+  config?: any;
+}
+
+export interface InstanceOptions {
+  transformRequest?: (data: any) => any;
+  transformResponse?: (data: any) => any;
+  headers?: any;
+  timeout?: number;
+  withCredentials?: boolean;
+  responseType?: string;
+  xsrfCookieName?: string;
+  xsrfHeaderName?: string;
+  paramsSerializer?: (params: any) => string;
+}
+
+export interface RequestOptions extends InstanceOptions {
+  url: string;
+  method?: string;
+  params?: any;
+  data?: any;
+}
+
+export interface SpecificRequestOptions extends InstanceOptions {
+  params?: any;
+  data?: any;
+}
+
+export function get(url: string, config?: any): Promise<Response>;
+export function _delete(url: string, config?: any): Promise<Response>;
+export {_delete as delete};
+export function head(url: string, config?: any): Promise<Response>;
+export function post(url: string, data: any, config?: any): Promise<Response>;
+export function put(url: string, data: any, config?: any): Promise<Response>;
+export function patch(url: string, data: any, config?: any): Promise<Response>;
+export function create(defaultOptions?: InstanceOptions): AxiosInstance;
+export function all(iterable: any): Promise<Response>;
+export function spread(callback: any): Promise<Response>;

--- a/package.json
+++ b/package.json
@@ -60,9 +60,7 @@
   "browser": {
     "./lib/adapters/http.js": "./lib/adapters/xhr.js"
   },
-  "typescript": {
-    "definition": "./axios.d.ts"
-  },
+  "typings": "axios.d.ts",
   "dependencies": {
     "follow-redirects": "0.0.7"
   }


### PR DESCRIPTION
There is a standard now to specify the typings file in package.json:

https://github.com/Microsoft/TypeScript/wiki/Typings-for-npm-packages

The "typescript" : {"definition": ""} was a suggestion that was never adopted.

This change will make axios work out of the box in typescript projects.