### PR TITLE
Add support for HTTP Basic auth via Authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ axios.get('/user?ID=12345')
   .catch(function (response) {
     console.log(response);
   });
-	
+
 // Optionally the request above could also be done as
 axios.get('/user', {
     params: {
@@ -174,7 +174,7 @@ These are the available config options for making requests. Only the `url` is re
   // The last function in the array must return a string or an ArrayBuffer
   transformRequest: [function (data) {
     // Do whatever you want to transform the data
-	
+
     return data;
   }],
 
@@ -182,7 +182,7 @@ These are the available config options for making requests. Only the `url` is re
   // it is passed to then/catch
   transformResponse: [function (data) {
     // Do whatever you want to transform the data
-	
+
     return data;
   }],
 
@@ -216,6 +216,8 @@ These are the available config options for making requests. Only the `url` is re
   withCredentials: false, // default
 
   // `auth` indicates that HTTP Basic auth should be used, and supplies credentials.
+  // This will set an `Authorization` header, overwriting any existing
+  // `Authorization` custom headers you have set using `headers`.
   // The username can be supplied as `user` or `username`
   // The password can be supplied as `pass` or `password`
   auth: {
@@ -246,7 +248,7 @@ The response for a request contains the following information.
 
   // `status` is the HTTP status code from the server response
   status: 200,
-  
+
   // `statusText` is the HTTP status message from the server response
   statusText: 'OK',
 

--- a/README.md
+++ b/README.md
@@ -218,11 +218,9 @@ These are the available config options for making requests. Only the `url` is re
   // `auth` indicates that HTTP Basic auth should be used, and supplies credentials.
   // This will set an `Authorization` header, overwriting any existing
   // `Authorization` custom headers you have set using `headers`.
-  // The username can be supplied as `user` or `username`
-  // The password can be supplied as `pass` or `password`
   auth: {
-    user: 'janedoe',
-    pass: 's00pers3cret'
+    username: 'janedoe',
+    password: 's00pers3cret'
   }
 
   // `responseType` indicates the type of data that the server will respond with

--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ These are the available config options for making requests. Only the `url` is re
   // should be made using credentials
   withCredentials: false, // default
 
+  // `auth` indicates that HTTP Basic auth should be used, and supplies credentials.
+  // The username can be supplied as `user` or `username`
+  // The password can be supplied as `pass` or `password`
+  auth: {
+    user: 'janedoe',
+    pass: 's00pers3cret'
+  }
+
   // `responseType` indicates the type of data that the server will respond with
   // options are 'arraybuffer', 'blob', 'document', 'json', 'text'
   responseType: 'json', // default

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -46,6 +46,14 @@ module.exports = function httpAdapter(resolve, reject, config) {
     headers['Content-Length'] = data.length;
   }
 
+  // HTTP basic authentication
+  var auth = undefined;
+  if (config.auth) {
+    var username = config.auth.user || config.auth.username;
+    var password = config.auth.pass || config.auth.password;
+    auth = username + ':' + password;
+  }
+
   // Parse url
   var parsed = url.parse(config.url);
   var options = {
@@ -54,7 +62,8 @@ module.exports = function httpAdapter(resolve, reject, config) {
     path: buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, ''),
     method: config.method,
     headers: headers,
-    agent: config.agent
+    agent: config.agent,
+    auth: auth
   };
 
   // Create the request

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -40,15 +40,15 @@ module.exports = function xhrAdapter(resolve, reject, config) {
   }
 
   // HTTP basic authentication
-  var configAuth = config.auth || {};
-  var auth = {
-    username: configAuth.username || configAuth.user || '',
-    password: configAuth.password || configAuth.pass || ''
-  };
+  if (config.auth) {
+    var username = config.auth.user || config.auth.username || '';
+    var password = config.auth.pass || config.auth.password || '';
+    requestHeaders['Authorization'] = 'Basic: ' + window.btoa(username + ':' + password);
+  }
 
   // Create the request
   var request = new adapter('Microsoft.XMLHTTP');
-  request.open(config.method.toUpperCase(), buildURL(config.url, config.params, config.paramsSerializer), true, auth.username, auth.password);
+  request.open(config.method.toUpperCase(), buildURL(config.url, config.params, config.paramsSerializer), true);
 
   // Set the request timeout in MS
   request.timeout = config.timeout;

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -41,9 +41,9 @@ module.exports = function xhrAdapter(resolve, reject, config) {
 
   // HTTP basic authentication
   if (config.auth) {
-    var username = config.auth.user || config.auth.username || '';
-    var password = config.auth.pass || config.auth.password || '';
     requestHeaders['Authorization'] = 'Basic: ' + window.btoa(username + ':' + password);
+    var username = config.auth.username || '';
+    var password = config.auth.password || '';
   }
 
   // Create the request

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -8,6 +8,7 @@ var buildURL = require('./../helpers/buildURL');
 var parseHeaders = require('./../helpers/parseHeaders');
 var transformData = require('./../helpers/transformData');
 var isURLSameOrigin = require('./../helpers/isURLSameOrigin');
+var btoa = window.btoa || require('./../helpers/btoa.js')
 
 module.exports = function xhrAdapter(resolve, reject, config) {
   // Transform request data
@@ -41,9 +42,9 @@ module.exports = function xhrAdapter(resolve, reject, config) {
 
   // HTTP basic authentication
   if (config.auth) {
-    requestHeaders['Authorization'] = 'Basic: ' + window.btoa(username + ':' + password);
     var username = config.auth.username || '';
     var password = config.auth.password || '';
+    requestHeaders['Authorization'] = 'Basic: ' + btoa(username + ':' + password);
   }
 
   // Create the request

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -39,10 +39,17 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     xDomain = true;
   }
 
+  // HTTP basic authentication
+  var configAuth = config.auth || {};
+  var auth = {
+    username: configAuth.username || configAuth.user || '',
+    password: configAuth.password || configAuth.pass || ''
+  };
+
   // Create the request
   var request = new adapter('Microsoft.XMLHTTP');
-  request.open(config.method.toUpperCase(), buildURL(config.url, config.params, config.paramsSerializer), true);
-  
+  request.open(config.method.toUpperCase(), buildURL(config.url, config.params, config.paramsSerializer), true, auth.username, auth.password);
+
   // Set the request timeout in MS
   request.timeout = config.timeout;
 

--- a/lib/helpers/btoa.js
+++ b/lib/helpers/btoa.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// btoa polyfill for IE<10 courtesy https://github.com/davidchambers/Base64.js
+
+var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+
+function InvalidCharacterError(message) {
+  this.message = message;
+}
+InvalidCharacterError.prototype = new Error;
+InvalidCharacterError.prototype.name = 'InvalidCharacterError';
+
+function btoa (input) {
+  var str = String(input);
+  for (
+    // initialize result and counter
+    var block, charCode, idx = 0, map = chars, output = '';
+    // if the next str index does not exist:
+    //   change the mapping table to "="
+    //   check if d has no fractional digits
+    str.charAt(idx | 0) || (map = '=', idx % 1);
+    // "8 - idx % 1 * 8" generates the sequence 2, 4, 6, 8
+    output += map.charAt(63 & block >> 8 - idx % 1 * 8)
+  ) {
+    charCode = str.charCodeAt(idx += 3/4);
+    if (charCode > 0xFF) {
+      throw new InvalidCharacterError('\'btoa\' failed: The string to be encoded contains characters outside of the Latin1 range.');
+    }
+    block = block << 8 | charCode;
+  }
+  return output;
+};
+
+module.exports = btoa

--- a/test/specs/basicAuth.spec.js
+++ b/test/specs/basicAuth.spec.js
@@ -1,0 +1,87 @@
+var axios = require('../../index');
+
+describe('options', function () {
+  beforeEach(function () {
+    jasmine.Ajax.install();
+  });
+
+  afterEach(function () {
+    jasmine.Ajax.uninstall();
+  });
+
+  it('should accept HTTP Basic auth with user/pass', function (done) {
+    var request;
+
+    axios({
+      url: '/foo',
+      auth: {
+        user: 'Aladdin',
+        pass: 'open sesame'
+      }
+    });
+
+    setTimeout(function () {
+      request = jasmine.Ajax.requests.mostRecent();
+
+      expect(request.requestHeaders['Authorization']).toEqual('Basic: QWxhZGRpbjpvcGVuIHNlc2FtZQ==');
+      done();
+    }, 0);
+  });
+
+  it('should accept HTTP Basic auth with username/pass', function (done) {
+    var request;
+
+    axios({
+      url: '/foo',
+      auth: {
+        username: 'Aladdin',
+        pass: 'open sesame'
+      }
+    });
+
+    setTimeout(function () {
+      request = jasmine.Ajax.requests.mostRecent();
+
+      expect(request.requestHeaders['Authorization']).toEqual('Basic: QWxhZGRpbjpvcGVuIHNlc2FtZQ==');
+      done();
+    }, 0);
+  });
+
+  it('should accept HTTP Basic auth with user/password', function (done) {
+    var request;
+
+    axios({
+      url: '/foo',
+      auth: {
+        user: 'Aladdin',
+        password: 'open sesame'
+      }
+    });
+
+    setTimeout(function () {
+      request = jasmine.Ajax.requests.mostRecent();
+
+      expect(request.requestHeaders['Authorization']).toEqual('Basic: QWxhZGRpbjpvcGVuIHNlc2FtZQ==');
+      done();
+    }, 0);
+  });
+
+  it('should accept HTTP Basic auth with username/password', function (done) {
+    var request;
+
+    axios({
+      url: '/foo',
+      auth: {
+        username: 'Aladdin',
+        password: 'open sesame'
+      }
+    });
+
+    setTimeout(function () {
+      request = jasmine.Ajax.requests.mostRecent();
+
+      expect(request.requestHeaders['Authorization']).toEqual('Basic: QWxhZGRpbjpvcGVuIHNlc2FtZQ==');
+      done();
+    }, 0);
+  });
+});

--- a/test/specs/basicAuthWithPolyfill.spec.js
+++ b/test/specs/basicAuthWithPolyfill.spec.js
@@ -1,6 +1,15 @@
 var axios = require('../../index');
 
-describe('basicAuth without btoa polyfill', function () {
+describe('basicAuth with btoa polyfill', function () {
+  beforeAll(function() {
+    this.original_btoa = window.btoa;
+    window.btoa = undefined;
+  })
+
+  afterAll(function() {
+    window.btoa = this.original_btoa;
+  })
+
   beforeEach(function () {
     jasmine.Ajax.install();
   });
@@ -36,7 +45,7 @@ describe('basicAuth without btoa polyfill', function () {
     }).then(function(response) {
       done(new Error('Should not succeed to make a HTTP Basic auth request with non-latin1 chars in credentials.'))
     }).catch(function(error) {
-      expect(error.message).toEqual('INVALID_CHARACTER_ERR: DOM Exception 5')
+      expect(error.message).toEqual('\'btoa\' failed: The string to be encoded contains characters outside of the Latin1 range.')
       done()
     });
   });


### PR DESCRIPTION
Fixes #78.

This is a resurrection of #130 with test and docs; it seems that effort stalled. I've rebased @lachenmayer's branch on top of latest master and dealt with conflicts, this should merge cleanly.

Most critically, it does not rely on URL embedded identities (aka `http://user:pass@example.com`). [Chrome 19 dropped support of URL embedded identities in XMLHttpRequest for security reasons](https://code.google.com/p/chromium/issues/detail?id=128323). Basic auth which relies on the trailing `user` and `pass` arguments to `XMLHttpRequest.open` will fail on some platforms. By contrast, `Authorization` headers work everywhere.

Thanks to @lachenmayer for the initial effort, and @mzabriskie for the lovely axios.