### PR TITLE
Only use XDomainRequest <= IE 9

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -8,6 +8,7 @@ var buildURL = require('./../helpers/buildURL');
 var parseHeaders = require('./../helpers/parseHeaders');
 var transformData = require('./../helpers/transformData');
 var isURLSameOrigin = require('./../helpers/isURLSameOrigin');
+var ieVersion = require('./../helpers/ieVersion');
 var btoa = window.btoa || require('./../helpers/btoa');
 
 module.exports = function xhrAdapter(resolve, reject, config) {
@@ -34,7 +35,7 @@ module.exports = function xhrAdapter(resolve, reject, config) {
   var xDomain = false;
 
   // For IE 8/9 CORS support
-  if (!isURLSameOrigin(config.url) && window.XDomainRequest) {
+  if (ieVersion() <= 9 && !isURLSameOrigin(config.url) && window.XDomainRequest) {
     Adapter = window.XDomainRequest;
     loadEvent = 'onload';
     xDomain = true;

--- a/lib/helpers/ieVersion.js
+++ b/lib/helpers/ieVersion.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/**
+ * https://gist.github.com/padolsey/527683
+ *
+ * A short snippet for detecting versions of IE in JavaScript
+ * without resorting to user-agent sniffing
+ *
+ * @returns {Number|undefined} Number of IE version (5-9), otherwise undefined
+ */
+module.exports = function ieVersion() {
+  var undef;
+  var v = 3;
+  var div = document.createElement('div');
+  var all = div.getElementsByTagName('i');
+
+  while ((
+    div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->',
+    all[0]
+  ));
+
+  return v > 4 ? v : undef;
+};


### PR DESCRIPTION
#177 

I have tested on Win8 IE10 and can confirm that it no longer uses XDomainRequest and that the 'transformResponse' in the examples works.

The GET and POST examples continue to work for IE9 (tested on Win7).