### PR TITLE
Fixes redirect behavior to correctly set host/port

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -45,7 +45,7 @@ module.exports = function httpAdapter(resolve, reject, config) {
   // Parse url
   var parsed = url.parse(config.url);
   var options = {
-    host: parsed.hostname,
+    hostname: parsed.hostname,
     port: parsed.port,
     path: buildURL(parsed.path, config.params, config.paramsSerializer).replace(/^\?/, ''),
     method: config.method,

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1,5 +1,6 @@
 var axios = require('../../../index');
 var http = require('http');
+var url = require('url');
 var zlib = require('zlib');
 var server;
 
@@ -23,6 +24,27 @@ module.exports = {
     }).listen(4444, function () {
       axios.get('http://localhost:4444/').then(function (res) {
         test.deepEqual(res.data, data);
+        test.done();
+      });
+    });
+  },
+
+  testRedirect: function (test) {
+    var str = 'test response';
+
+    server = http.createServer(function (req, res) {
+      var parsed = url.parse(req.url);
+
+      if (parsed.pathname === '/one') {
+        res.setHeader('Location', '/two');
+        res.statusCode = 302;
+        res.end();
+      } else {
+        res.end(str);
+      }
+    }).listen(4444, function () {
+      axios.get('http://localhost:4444/one').then(function (res) {
+        test.equal(res.data, str);
         test.done();
       });
     });


### PR DESCRIPTION
We currently supply options to `follow-redirects` in the format `{ host, port }`, but the port is incorrectly dropped during redirect due to the way that `url.format` handles `host` vs `hostname`. For the purposes of `http`, `host` and `hostname` are aliases, but when building the redirect URL, `host` is assumed to be the full origin. We should supply `hostname` instead.

I have added a test for this case. I you change the options to use `host` instead of `hostname`, the tests will hang as the request is being incorrectly redirected to "http://localhost/two" instead of "http://localhost:4444/two".