### PR TITLE
Fix typo

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -8,7 +8,7 @@ var DEFAULT_CONTENT_TYPE = {
 };
 
 module.exports = {
-  transformRequest: [function transformResponseJSON(data, headers) {
+  transformRequest: [function transformRequestJSON(data, headers) {
     if (utils.isFormData(data)) {
       return data;
     }


### PR DESCRIPTION
Small fix and a question.

Can't I add a handler into `interceptors.request` for converting request data into `FormData` when `Content-Type` is `multipart/form-data`? From `v0.9.0` request data (type of `Object`) will be converted into `String` in `transformRequestJSON()`, and added handler is called after `JSON.stringify()`.

Should I pass `FormData` as data?