### PR TITLE
Handle timeout on XHR requests

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -76,6 +76,14 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     request = null;
   };
 
+  // Handle timeout
+  request.ontimeout = function handleTimeout() {
+    reject(new Error('Timeout'));
+
+    // Clean up request
+    request = null;
+  };
+
   // Add xsrf header
   // This is only done if running in a standard browser environment.
   // Specifically not if we're in a web worker, or react-native.


### PR DESCRIPTION
Rejects the promise when a XHR timeout happens, solving issue #226 