### PR TITLE
Adding support for userscripting (Greasemonkey and derivatives)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Promise based HTTP client for the browser and node.js
 ## Features
 
 - Make [XMLHttpRequests](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) from the browser
+- Make [GM_xmlhttpRequest](http://wiki.greasespot.net/GM_xmlhttpRequest) requests from [Greasemonkey](https://addons.mozilla.org/en-US/firefox/addon/greasemonkey/) for Firefox and derivatives including [Tampermonkey](https://tampermonkey.net/) for Chrome
 - Make [http](http://nodejs.org/api/http.html) requests from node.js
 - Supports the [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) API
 - Intercept request and response

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -6,6 +6,7 @@ var parseHeaders = require('./../helpers/parseHeaders');
 var transformData = require('./../helpers/transformData');
 var isURLSameOrigin = require('./../helpers/isURLSameOrigin');
 var btoa = window.btoa || require('./../helpers/btoa');
+var GmXhr = require('./../helpers/GmXhr');
 
 module.exports = function xhrAdapter(resolve, reject, config) {
   var requestData = config.data;
@@ -15,7 +16,17 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     delete requestHeaders['Content-Type']; // Let the browser set it
   }
 
-  var request = new XMLHttpRequest();
+  // Are we running under Greasemonkey (or a derivative)?
+  var Adapter = null;
+  try {
+    Adapter = GM_xmlhttpRequest; /*eslint camelcase:0*/
+    // If above line doesn't throw exception, then this is GM
+    Adapter = GmXhr; // then use xhr wrapper class for GM_xmlhttpRequest
+  } catch (err) { // Otherwise, not running under Greasemonkey
+    Adapter = XMLHttpRequest;
+  }
+
+  var request = new Adapter();
 
   // For IE 8/9 CORS support
   // Only supports POST and GET calls and doesn't returns the response headers.

--- a/lib/helpers/GmXhr.js
+++ b/lib/helpers/GmXhr.js
@@ -1,0 +1,118 @@
+// allows using all Jquery AJAX methods in Greasemonkey
+// https://gist.github.com/damoclark/f01b957797b7dd2c33d6
+// https://gist.github.com/monperrus/999065
+// inspired from
+//   http://ryangreenberg.com/archives/2010/03/greasemonkey_jquery.php
+// works with JQuery 1.5
+// (c) 2016 Damien Clark
+// (c) 2011 Martin Monperrus
+// (c) 2010 Ryan Greenberg
+//
+// Example usage with JQuery:
+//   $.ajax({
+//     url: '/p/',
+//     xhr: function(){return new GmXhr();},
+//     type: 'POST',
+//     success: function(val){
+//        ....
+//     }
+//   });
+
+'use strict';
+
+/**
+ * xmlHttpRequest API wrapper for GM_xmlhttpRequest
+ *
+ * @returns {GmXhr} An instance with a compatible API to xmlHttpRequest
+ */
+function GmXhr() {
+  this.type = null;
+  this.url = null;
+  this.async = null;
+  this.username = null;
+  this.password = null;
+  this.status = null;
+  this.headers = {};
+  this.readyState = null;
+}
+
+GmXhr.prototype.abort = function abort() {
+  this.readyState = 0;
+};
+
+GmXhr.prototype.getAllResponseHeaders = function getAllResponseHeaders() {
+  if (this.readyState !== 4) return '';
+  return this.responseHeaders;
+};
+
+GmXhr.prototype.getResponseHeader = function getResponseHeader(name) {
+  var regexp = new RegExp('^' + name + ': (.*)$', 'im');
+  var match = regexp.exec(this.responseHeaders);
+  if (match) { return match[1]; }
+  return '';
+};
+
+GmXhr.prototype.open = function open(type, url, async, username, password) {
+  this.type = type
+    ? type
+    : null;
+  this.url = url
+    ? url
+    : null;
+  this.async = async
+    ? async
+    : null;
+  this.username = username
+    ? username
+    : null;
+  this.password = password
+    ? password
+    : null;
+  this.readyState = 1;
+};
+
+GmXhr.prototype.setRequestHeader = function setRequestHeader(name, value) {
+  this.headers[name] = value;
+};
+
+GmXhr.prototype.send = function send(data) {
+  this.data = data;
+  var that = this;
+  // http://wiki.greasespot.net/GM_xmlhttpRequest
+  GM_xmlhttpRequest({ /*eslint new-cap:0*/
+    method: this.type,
+    url: this.url,
+    headers: this.headers,
+    data: this.data,
+    onload: function onload(rsp) {
+      // Populate wrapper object with returned data
+      // including the Greasemonkey specific "responseHeaders"
+      for (var k in rsp) {
+        if (rsp.hasOwnProperty(k)) {
+          that[k] = rsp[k];
+        }
+      }
+      // now we call onreadystatechange
+      if (that.hasOwnProperty('onreadystatechange')) {
+        that.onreadystatechange();
+      } else { // otherwise call onload
+        that.onload();
+      }
+    },
+    onerror: function onerror(rsp) {
+      for (var k in rsp) {
+        if (rsp.hasOwnProperty(k)) {
+          that[k] = rsp[k];
+        }
+      }
+      // now we call onreadystatechange
+      if (that.hasOwnProperty('onreadystatechange')) {
+        that.onreadystatechange();
+      } else {
+        that.onerror(); // otherwise call onerror
+      }
+    }
+  });
+};
+
+module.exports = GmXhr;


### PR DESCRIPTION
Hey Matt,

I deleted the previous PR, and created a new cleaner PR. 

This is a simple contribution that allows Axios to be easily used in browser userscripts, such as Greasemonkey, Tampermonkey etc. The patch is quite modest in terms of changes. 

I am maintaining a separate fork of axios to provide this functionality.  If you decide to merge, let me know.

Regards,
Damien.