### PR TITLE
switches check order of xhr/http for electron

### DIFF
--- a/lib/core/dispatchRequest.js
+++ b/lib/core/dispatchRequest.js
@@ -15,12 +15,12 @@ module.exports = function dispatchRequest(config) {
       if (typeof config.adapter === 'function') {
         // For custom adapter support
         adapter = config.adapter;
-      } else if (typeof XMLHttpRequest !== 'undefined') {
-        // For browsers use XHR adapter
-        adapter = require('../adapters/xhr');
       } else if (typeof process !== 'undefined') {
         // For node use HTTP adapter
         adapter = require('../adapters/http');
+      } else if (typeof XMLHttpRequest !== 'undefined') {
+        // For browsers use XHR adapter
+        adapter = require('../adapters/xhr');
       }
 
       if (typeof adapter === 'function') {


### PR DESCRIPTION
Electron has a Node `process` *and* the `window.XMLHttpRequest` but axios would default to using the XHR  because the XHR `if` statement came first.  I think it would be more appropriate to use the Node HTTP request in Electron, or at all if it exists.