### PR TITLE
Fixing IE8 support by bringing back onreadystatechange

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -16,11 +16,15 @@ module.exports = function xhrAdapter(resolve, reject, config) {
   }
 
   var request = new XMLHttpRequest();
+  var loadEvent = 'onreadystatechange';
+  var xDomain = false;
 
   // For IE 8/9 CORS support
   // Only supports POST and GET calls and doesn't returns the response headers.
   if (window.XDomainRequest && !('withCredentials' in request) && !isURLSameOrigin(config.url)) {
     request = new window.XDomainRequest();
+    loadEvent = 'onload';
+    xDomain = true;
   }
 
   // HTTP basic authentication
@@ -36,13 +40,20 @@ module.exports = function xhrAdapter(resolve, reject, config) {
   request.timeout = config.timeout;
 
   // Listen for ready state
-  request.onload = function handleLoad() {
-    if (!request) {
+  request[loadEvent] = function handleLoad() {
+    if (!request || (request.readyState !== 4 && !xDomain)) {
       return;
     }
+
+    // The request errored out and we didn't get a response, this will be
+    // handled by onerror instead
+    if (request.status === 0) {
+      return;
+    }
+
     // Prepare the response
     var responseHeaders = 'getAllResponseHeaders' in request ? parseHeaders(request.getAllResponseHeaders()) : null;
-    var responseData = ['text', ''].indexOf(config.responseType || '') !== -1 ? request.responseText : request.response;
+    var responseData = !config.responseType || config.responseType === 'text' ? request.responseText : request.response;
     var response = {
       data: transformData(
         responseData,


### PR DESCRIPTION
Bringing back `onreadystatechange` is a little tricky, since it's also called for requests that errored out.
As far as I can see, and after testing it in a few browsers, checking for `request.status === 0` is a decent way to know that no real response was received and `onerror` will be called.

I've also removed the use of `Array.prototype.indexOf` since that's not available in IE8.