### PR TITLE
IE9 fix for cross domain calls

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -58,7 +58,7 @@ module.exports = function xhrAdapter(resolve, reject, config) {
 
     // Resolve or reject the Promise based on the status
     ((response.status >= 200 && response.status < 300) ||
-     (!('status' in request) && response.responseText) ?
+     (!('status' in request) && request.responseText) ?
       resolve :
       reject)(response);
 

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -35,6 +35,10 @@ module.exports = function xhrAdapter(resolve, reject, config) {
   // Set the request timeout in MS
   request.timeout = config.timeout;
 
+  // For IE 9 CORS support.
+  request.onprogress = function() {};
+  request.ontimeout = function() {};
+
   // Listen for ready state
   request.onload = function handleLoad() {
     if (!request) {


### PR DESCRIPTION
This pull request includes these fixes for IE9:
1) Fixed axios promise rejection on request onload for cors api calls.
2) Fixed cors api calls timing out prematurely. 