### PR TITLE
doc(readme): uses latest syntax for Typescript import

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ If your environment doesn't support ES6 Promises, you can [polyfill](https://git
 axios includes a [TypeScript](http://typescriptlang.org) definition.
 ```typescript
 /// <reference path="axios.d.ts" />
-import axios = require('axios');
+import * as axios from 'axios';
 axios.get('/user?ID=12345');
 ```
 


### PR DESCRIPTION
Since 1.5 this feature is available, I thought it'd be good to have it in the readme :smile: 