### PR TITLE
Fixing issues with peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "karma-webpack": "1.7.0",
     "load-grunt-tasks": "3.4.1",
     "minimist": "1.2.0",
-    "phantomjs": "2.1.3",
+    "phantomjs-prebuilt": "2.1.6",
+    "sinon": "1.17.3",
     "webpack": "1.12.14",
     "webpack-dev-server": "1.14.1"
   },


### PR DESCRIPTION
I've just tried to run tests and faced the following issue: 

```
21 03 2016 17:38:44.495:WARN [plugin]: Error during loading "/Users/nickuraltsev/Projects/axios/node_modules/karma-phantomjs-launcher" plugin: 
Cannot find module 'phantomjs-prebuilt'
```

Turns out `phantomjs` module was renamed to `phantomjs-prebuilt` (see [this issue](https://github.com/karma-runner/karma-phantomjs-launcher/issues/104)) so I updated package.json to use `phantomjs-prebuilt` to fix the problem. 

I also had to add `sinon` to the list of dev deps to fix another issue: unmet peer dependency. Please note that I'm using npm 3.