### PR TITLE
fix get parameter list

### DIFF
--- a/lib/helpers/buildURL.js
+++ b/lib/helpers/buildURL.js
@@ -13,6 +13,25 @@ function encode(val) {
     replace(/%5D/gi, ']');
 }
 
+function flatten(val, key) {
+  var ret = {};
+
+  utils.forEach(val, function _flatten(v, k) {
+    var paramKey = key ? key + '[' + k + ']' : k;
+
+    if (utils.isDate(v)) {
+      ret[paramKey] = v.toISOString();
+    } else if (utils.isObject(v)) {
+      v = flatten(v, paramKey);
+      Object.assign(ret, v);
+    } else {
+      ret[paramKey] = v;
+    }
+  });
+
+  return ret;
+}
+
 /**
  * Build a URL by appending params to the end
  *
@@ -30,9 +49,10 @@ module.exports = function buildURL(url, params, paramsSerializer) {
   if (paramsSerializer) {
     serializedParams = paramsSerializer(params);
   } else {
+    var flattenParams = flatten(params);
     var parts = [];
 
-    utils.forEach(params, function serialize(val, key) {
+    utils.forEach(flattenParams, function serialize(val, key) {
       if (val === null || typeof val === 'undefined') {
         return;
       }
@@ -46,11 +66,6 @@ module.exports = function buildURL(url, params, paramsSerializer) {
       }
 
       utils.forEach(val, function parseValue(v) {
-        if (utils.isDate(v)) {
-          v = v.toISOString();
-        } else if (utils.isObject(v)) {
-          v = JSON.stringify(v);
-        }
         parts.push(encode(key) + '=' + encode(v));
       });
     });
@@ -64,4 +79,3 @@ module.exports = function buildURL(url, params, paramsSerializer) {
 
   return url;
 };
-

--- a/test/specs/helpers/buildURL.spec.js
+++ b/test/specs/helpers/buildURL.spec.js
@@ -16,7 +16,28 @@ describe('helpers::buildURL', function () {
       foo: {
         bar: 'baz'
       }
-    })).toEqual('/foo?foo=' + encodeURI('{"bar":"baz"}'));
+    })).toEqual('/foo?foo[bar]=baz');
+  });
+
+  it('should support nested object params', function () {
+    expect(buildURL('/foo', {
+      foo: {
+        bar: 'baz',
+        far: {
+          bla: 'boz',
+          lala: [
+            {
+              ba: 'a',
+              da: 'b'
+            },
+            {
+              sa: 'c',
+              ha: 'd'
+            }
+          ]
+        }
+      }
+    })).toEqual('/foo?foo[bar]=baz&foo[far][bla]=boz&foo[far][lala][0][ba]=a&foo[far][lala][0][da]=b&foo[far][lala][1][sa]=c&foo[far][lala][1][ha]=d');
   });
 
   it('should support date params', function () {
@@ -60,7 +81,7 @@ describe('helpers::buildURL', function () {
     expect(buildURL('/foo', params, serializer)).toEqual('/foo?foo=bar');
     expect(serializer.calledOnce).toBe(true);
     expect(serializer.calledWith(params)).toBe(true);
-  })
+  });
 });
 
 


### PR DESCRIPTION
JSON.stringify() might not be the best way for making the GET parameter list.
The right way should be flattening inner objects and lists also.