### PR TITLE
Fix issue with ArrayBuffer

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -158,11 +158,6 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     }
   }
 
-  // Format request data
-  if (utils.isArrayBuffer(requestData)) {
-    requestData = new DataView(requestData);
-  }
-
   if (requestData === undefined) {
     requestData = null;
   }

--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -71,7 +71,7 @@ describe('requests', function () {
           'Content-Type': 'application/json'
         }
       });
-      
+
       setTimeout(function () {
         expect(response.data.foo).toEqual('bar');
         expect(response.status).toEqual(200);
@@ -164,7 +164,7 @@ describe('requests', function () {
     axios.post('/foo', input.buffer);
 
     getAjaxRequest().then(function (request) {
-      var output = new Int8Array(request.params.buffer);
+      var output = new Int8Array(request.params);
       expect(output.length).toEqual(2);
       expect(output[0]).toEqual(1);
       expect(output[1]).toEqual(2);
@@ -186,7 +186,7 @@ describe('requests', function () {
     axios.post('/foo', input);
 
     getAjaxRequest().then(function (request) {
-      var output = new Int8Array(request.params.buffer);
+      var output = new Int8Array(request.params);
       expect(output.length).toEqual(2);
       expect(output[0]).toEqual(1);
       expect(output[1]).toEqual(2);
@@ -200,7 +200,7 @@ describe('requests', function () {
       done();
       return;
     }
-    
+
     var response;
 
     function str2ab(str) {


### PR DESCRIPTION
I think we should not wrap an `ArrayBuffer` in a `DataView`. `XMLHttpRequest#send(ArrayBuffer)` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#send()), but `XMLHttpRequest#send(ArrayBufferView)` does not seem to be supported by some browsers like IE 11. BTW, fetch sends an `ArrayBuffer` as is, so my suggestion is to do the same.

This PR fixes #268.