### PR TITLE
Only set empty handlers for IE CORS support if using XDomainRequest

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -27,6 +27,8 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     request = new window.XDomainRequest();
     loadEvent = 'onload';
     xDomain = true;
+    request.onprogress = function handleProgress() {};
+    request.ontimeout = function handleTimeout() {};
   }
 
   // HTTP basic authentication
@@ -40,10 +42,6 @@ module.exports = function xhrAdapter(resolve, reject, config) {
 
   // Set the request timeout in MS
   request.timeout = config.timeout;
-
-  // For IE 9 CORS support.
-  request.onprogress = function handleProgress() {};
-  request.ontimeout = function handleTimeout() {};
 
   // Listen for ready state
   request[loadEvent] = function handleLoad() {


### PR DESCRIPTION
I ran into a mysterious issue after upgrading Axios from 0.9.1 to 0.11.0 where a Selenium test was timing out only on Firefox, and was able to bisect the issue down to [this commit](https://github.com/mzabriskie/axios/commit/1696d1ca5501314a3dcf97b7ceb761de23861d46). I'm assuming that this change was added based on the workaround for the issue reported [here](http://perrymitchell.net/article/xdomainrequest-cors-ie9/).

The problem seems to be that these handlers are being set on the request, even in test mode, which seems to have an unintended effect on promise resolution in Selenium, which I assume uses these handlers, but I haven't been able to find an exact path to track down the root cause.

This PR moves the workaround into the block that sets `request` to an `XDomainRequest`, and fixes the issue. I'm assuming there isn't a reason that these should be set to empty handlers in any other case.