### PR TITLE
Adding erroneous and timed-out requests the ability to be replayed

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -80,9 +80,12 @@ module.exports = function xhrAdapter(resolve, reject, config) {
 
   // Handle low level network errors
   request.onerror = function handleError() {
+    var err = new Error('Network Error');
+    err.code = 'EREQUESTERROR';
+    err.request = request;
     // Real errors are hidden from us by the browser
     // onerror should only fire if it's a network error
-    reject(new Error('Network Error'));
+    reject(err);
 
     // Clean up request
     request = null;
@@ -93,6 +96,7 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     var err = new Error('timeout of ' + config.timeout + 'ms exceeded');
     err.timeout = config.timeout;
     err.code = 'ECONNABORTED';
+    err.request = request;
     reject(err);
 
     // Clean up request


### PR DESCRIPTION
I was reading #164 and looked for a way to retry a timed-out / erroneous request. After reading the code, I realized it was not possible since the original request parameters were not bubbling in the Error. I've not tested any implementation of the full retry interceptor, but from my PoV, it should be enough.

I've also added an error code to erroneous request to be consistent with the timed-out request.