### PR TITLE
Enhance the thrown errors with a .config and .request property.

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -83,6 +83,7 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     // Real errors are hidden from us by the browser
     // onerror should only fire if it's a network error
     var err = new Error('Network Error');
+    err.code = 'EREQUESTERROR';
     err.config = config;
     err.request = request;
     reject(err);

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -82,7 +82,10 @@ module.exports = function xhrAdapter(resolve, reject, config) {
   request.onerror = function handleError() {
     // Real errors are hidden from us by the browser
     // onerror should only fire if it's a network error
-    reject(new Error('Network Error'));
+    var err = new Error('Network Error');
+    err.config = config;
+    err.request = request;
+    reject(err);
 
     // Clean up request
     request = null;
@@ -93,6 +96,8 @@ module.exports = function xhrAdapter(resolve, reject, config) {
     var err = new Error('timeout of ' + config.timeout + 'ms exceeded');
     err.timeout = config.timeout;
     err.code = 'ECONNABORTED';
+    err.config = config;
+    err.request = request;
     reject(err);
 
     // Clean up request


### PR DESCRIPTION
This makes it comparable to the default rejected payload of a failed request. It would make debugging these errors easier. 

https://github.com/mzabriskie/axios/issues/242