### PR TITLE
Allow xsrfHeaderName to be a function

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -109,7 +109,11 @@ module.exports = function xhrAdapter(resolve, reject, config) {
         undefined;
 
     if (xsrfValue) {
-      requestHeaders[config.xsrfHeaderName] = xsrfValue;
+      if (typeof config.xsrfHeaderName === 'function') {
+        requestHeaders = config.xsrfHeaderName(xsrfValue, requestHeaders) || requestHeaders;
+      } else {
+        requestHeaders[config.xsrfHeaderName] = xsrfValue;
+      }
     }
   }
 


### PR DESCRIPTION
If it is a function then it will be passed the XSRF token and the `requestHeaders` object allowing you to put the XSRF token wherever you want inside the headers. For instance:

```js
axios.get('https://api.example.com', {
  xsrfHeaderName: function (token, headers) {
    headers['Authorization'] = 'Bearer ' + token
  }
})
```