### PR TITLE
Fixing Authorization header with basic auth

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -62,6 +62,10 @@ module.exports = function httpAdapter(config) {
       auth = urlUsername + ':' + urlPassword;
     }
 
+    if (auth) {
+      delete headers.Authorization;
+    }
+
     var isHttps = parsed.protocol === 'https:';
     var agent = isHttps ? config.httpsAgent : config.httpAgent;
 

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -168,8 +168,23 @@ module.exports = {
       res.end(req.headers.authorization);
     }).listen(4444, function () {
       var user = 'foo';
-      axios.get('http://' + user + '@localhost:4444/').then(function (res) {
+      var headers = { Authorization: 'Bearer 1234' };
+      axios.get('http://' + user + '@localhost:4444/', { headers: headers }).then(function (res) {
         var base64 = new Buffer(user + ':', 'utf8').toString('base64');
+        test.equal(res.data, 'Basic ' + base64);
+        test.done();
+      });
+    });
+  },
+
+  testBasicAuthWithHeader: function (test) {
+    server = http.createServer(function (req, res) {
+      res.end(req.headers.authorization);
+    }).listen(4444, function () {
+      var auth = { username: 'foo', password: 'bar' };
+      var headers = { Authorization: 'Bearer 1234' };
+      axios.get('http://localhost:4444/', { auth: auth, headers: headers }).then(function (res) {
+        var base64 = new Buffer('foo:bar', 'utf8').toString('base64');
         test.equal(res.data, 'Basic ' + base64);
         test.done();
       });


### PR DESCRIPTION
The http adapter did not remove a custom Authorization header when auth is set (as it is state in the documentation).