### PR TITLE
Fixing xsrf header on missing xsrfCookieName

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -103,7 +103,7 @@ module.exports = function xhrAdapter(config) {
       var cookies = require('./../helpers/cookies');
 
       // Add xsrf header
-      var xsrfValue = config.withCredentials || isURLSameOrigin(config.url) ?
+      var xsrfValue = (config.withCredentials || isURLSameOrigin(config.url)) && config.xsrfCookieName ?
           cookies.read(config.xsrfCookieName) :
           undefined;
 

--- a/test/specs/xsrf.spec.js
+++ b/test/specs/xsrf.spec.js
@@ -28,6 +28,19 @@ describe('xsrf', function () {
     });
   });
 
+  it('should not set xsrf header if xsrfCookieName is null', function (done) {
+    document.cookie = axios.defaults.xsrfCookieName + '=12345';
+
+    axios('/foo', {
+      xsrfCookieName: null
+    });
+
+    getAjaxRequest().then(function (request) {
+      expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toEqual(undefined);
+      done();
+    });
+  });
+
   it('should not set xsrf header for cross origin', function (done) {
     document.cookie = axios.defaults.xsrfCookieName + '=12345';
 

--- a/test/specs/xsrf.spec.js
+++ b/test/specs/xsrf.spec.js
@@ -1,3 +1,5 @@
+var cookies = require('../../lib/helpers/cookies');
+
 describe('xsrf', function () {
   beforeEach(function () {
     jasmine.Ajax.install();
@@ -37,6 +39,19 @@ describe('xsrf', function () {
 
     getAjaxRequest().then(function (request) {
       expect(request.requestHeaders[axios.defaults.xsrfHeaderName]).toEqual(undefined);
+      done();
+    });
+  });
+
+  it('should not read cookies at all if xsrfCookieName is null', function (done) {
+    spyOn(cookies, "read");
+
+    axios('/foo', {
+      xsrfCookieName: null
+    });
+
+    getAjaxRequest().then(function (request) {
+      expect(cookies.read).not.toHaveBeenCalled();
       done();
     });
   });


### PR DESCRIPTION
This change introduce a way to disable cookies reading and fix #395.