### PR TITLE
Fixing URLSearchParams polyfills

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var bind = require('./helpers/bind');
+var URLSearchParams = require('url-search-params');
 
 /*global toString:true*/
 
@@ -151,7 +152,7 @@ function isStream(val) {
  * @returns {boolean} True if value is a URLSearchParams object, otherwise false
  */
 function isURLSearchParams(val) {
-  return typeof URLSearchParams !== 'undefined' && val instanceof URLSearchParams;
+  return val instanceof URLSearchParams;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
     "phantomjs-prebuilt": "^2.1.7",
     "sinon": "^1.17.4",
     "webpack": "^1.13.1",
-    "webpack-dev-server": "^1.14.1",
-    "url-search-params": "^0.5.0"
+    "webpack-dev-server": "^1.14.1"
   },
   "browser": {
     "./lib/adapters/http.js": "./lib/adapters/xhr.js"
@@ -73,6 +72,7 @@
     "definition": "./axios.d.ts"
   },
   "dependencies": {
-    "follow-redirects": "0.0.7"
+    "follow-redirects": "0.0.7",
+    "url-search-params": "^0.5.0"
   }
 }


### PR DESCRIPTION
When using axios on browsers that don't directly support
URLSearchParams (such as IE, Edge, or Safari), I was unable to
successfully use the polyfill provided by
[url-search-params](https://github.com/WebReflection/url-search-params)
to send a request as `Content-Type` =
`application/x-www-form-urlencoded;charset=UTF-8`. By moving the
polyfill to a regular dependency and importing it into the utils.js, it
now works everywhere for me (directly supported or polyfill).