### PR TITLE
Adding note about ES6 Promise polyfill in the Interceptors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ instance.get('/longRequest', {
 
 ## Interceptors
 
-You can intercept requests or responses before they are handled by `then` or `catch`.
+You can intercept requests or responses before they are handled by `then` or `catch`. The example below uses `Promise`, which needs to be polyfilled in your environment if it's not supported natively. See the section on [ES6 Promise Polyfill](/UPGRADE_GUIDE.md#es6-promise-polyfill) in the [Upgrade guide](/UPGRADE_GUIDE.md).
 
 ```js
 // Add a request interceptor


### PR DESCRIPTION
The [Interceptors](https://github.com/mzabriskie/axios#interceptors) section uses `Promise` in its example. It may not be obvious to new users that they need to use `require('es6-promise').polyfill()`, as mentioned in the [ES6 Promise Polyfill](https://github.com/mzabriskie/axios/blob/master/UPGRADE_GUIDE.md#es6-promise-polyfill) section of the Upgrade Guide. Thanks!