### PR TITLE
Split progress event handlers into upload and download. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,13 +270,13 @@ These are the available config options for making requests. Only the `url` is re
   // `xsrfHeaderName` is the name of the http header that carries the xsrf token value
   xsrfHeaderName: 'X-XSRF-TOKEN', // default
 
-  // `progressUpload` allows handling of progress events for uploads
-  progressUpload: function (progressEvent) {
+  // `onUploadProgress` allows handling of progress events for uploads
+  onUploadProgress: function (progressEvent) {
     // Do whatever you want with the native progress event
   },
 
-  // `progressDownload` allows handling of progress events for downloads
-  progressDownload: function (progressEvent) {
+  // `onDownloadProgress` allows handling of progress events for downloads
+  onDownloadProgress: function (progressEvent) {
     // Do whatever you want with the native progress event
   },
 

--- a/README.md
+++ b/README.md
@@ -270,9 +270,13 @@ These are the available config options for making requests. Only the `url` is re
   // `xsrfHeaderName` is the name of the http header that carries the xsrf token value
   xsrfHeaderName: 'X-XSRF-TOKEN', // default
 
-  // `progress` allows handling of progress events for 'POST' and 'PUT uploads'
-  // as well as 'GET' downloads
-  progress: function (progressEvent) {
+  // `progressUpload` allows handling of progress events for uploads
+  progressUpload: function (progressEvent) {
+    // Do whatever you want with the native progress event
+  },
+
+  // `progressDownload` allows handling of progress events for downloads
+  progressDownload: function (progressEvent) {
     // Do whatever you want with the native progress event
   },
 

--- a/examples/upload/index.html
+++ b/examples/upload/index.html
@@ -27,7 +27,7 @@
           data.append('file', document.getElementById('file').files[0]);
 
           var config = {
-            progress: function(progressEvent) {
+            progressUpload: function(progressEvent) {
               var percentCompleted = progressEvent.loaded / progressEvent.total;
             }
           };

--- a/examples/upload/index.html
+++ b/examples/upload/index.html
@@ -27,7 +27,7 @@
           data.append('file', document.getElementById('file').files[0]);
 
           var config = {
-            progressUpload: function(progressEvent) {
+            onUploadProgress: function(progressEvent) {
               var percentCompleted = progressEvent.loaded / progressEvent.total;
             }
           };

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -142,13 +142,14 @@ module.exports = function xhrAdapter(config) {
     }
 
     // Handle progress if needed
-    if (typeof config.progress === 'function') {
-      if (config.method === 'post' || config.method === 'put') {
-        request.upload.addEventListener('progress', config.progress);
-      } else if (config.method === 'get') {
-        request.addEventListener('progress', config.progress);
-      }
+    if (typeof config.progressDownload === 'function') {
+      request.addEventListener('progress', config.progressDownload);
     }
+
+    if (typeof config.progressUpload === 'function') {
+      request.upload.addEventListener('progress', config.progressUpload);
+    }
+
 
     if (requestData === undefined) {
       requestData = null;

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -142,12 +142,13 @@ module.exports = function xhrAdapter(config) {
     }
 
     // Handle progress if needed
-    if (typeof config.progressDownload === 'function') {
-      request.addEventListener('progress', config.progressDownload);
+    if (typeof config.onDownloadProgress === 'function') {
+      request.addEventListener('progress', config.onDownloadProgress);
     }
 
-    if (typeof config.progressUpload === 'function') {
-      request.upload.addEventListener('progress', config.progressUpload);
+    // Not all browsers support upload events
+    if (typeof config.onUploadProgress === 'function' && request.upload) {
+      request.upload.addEventListener('progress', config.onUploadProgress);
     }
 
 

--- a/test/specs/progress.spec.js
+++ b/test/specs/progress.spec.js
@@ -106,7 +106,6 @@ describe('progress events', function () {
       });
       expect(downloadProgressSpy).toHaveBeenCalled();
       done();
-      done();
     });
   });
 });

--- a/test/specs/progress.spec.js
+++ b/test/specs/progress.spec.js
@@ -1,4 +1,4 @@
-describe('progress events', function () {
+fdescribe('progress events', function () {
   beforeEach(function () {
     jasmine.Ajax.install();
   });
@@ -8,86 +8,104 @@ describe('progress events', function () {
   });
 
   it('should add a download progress handler', function (done) {
-    function progressHandler(event) {};
+    var progressSpy = jasmine.createSpy('progress');
 
-    axios('/foo', { progressDownload: progressHandler } );
+    axios('/foo', { onDownloadProgress: progressSpy } );
 
     getAjaxRequest().then(function (request) {
-      // Not sure of the best way to test this, so just test that the new listener is present
-      expect(request.eventBus.eventList.progress.length).toEqual(2);
+      request.respondWith({
+        status: 200,
+        responseText: '{"foo": "bar"}'
+      });
+      expect(progressSpy).toHaveBeenCalled();
       done();
     });
   });
 
   it('should add a upload progress handler', function (done) {
-    function progressHandler(event) {};
+    var progressSpy = jasmine.createSpy('progress');
 
-    axios('/foo', { progressUpload: progressHandler } );
+    axios('/foo', { onUploadProgress: progressSpy } );
 
     getAjaxRequest().then(function (request) {
-      // Jasmine-Ajax fake XHR upload events are broken, so for now just test that nothing breaks/crashes
-      // expect(request.upload.eventBus.eventList.progress.length).toEqual(2);
+      // Jasmine AJAX doesn't trigger upload events. Waiting for upstream fix
+      // expect(progressSpy).toHaveBeenCalled();
       done();
     });
   });
 
   it('should add both upload and download progress handlers', function (done) {
-    function progressHandler(event) {};
+    var downloadProgressSpy = jasmine.createSpy('downloadProgress');
+    var uploadProgressSpy = jasmine.createSpy('uploadProgress');
 
-    axios('/foo', { progressDownload: progressHandler, progressUpload: progressHandler });
+    axios('/foo', { onDownloadProgress: downloadProgressSpy, onUploadProgress: uploadProgressSpy });
 
     getAjaxRequest().then(function (request) {
-      expect(request.eventBus.eventList.progress.length).toEqual(2);
-      // Jasmine-Ajax fake XHR upload events are broken, so for now just test that nothing breaks/crashes
-      // expect(request.upload.eventBus.eventList.progress.length).toEqual(2);
+      // expect(uploadProgressSpy).toHaveBeenCalled();
+      expect(downloadProgressSpy).not.toHaveBeenCalled();
+      request.respondWith({
+        status: 200,
+        responseText: '{"foo": "bar"}'
+      });
+      expect(downloadProgressSpy).toHaveBeenCalled();
       done();
     });
   });
 
   it('should add a download progress handler from instance config', function (done) {
-    function progressHandler(event) {};
+    var progressSpy = jasmine.createSpy('progress');
 
     var instance = axios.create({
-      progressDownload: progressHandler,
+      onDownloadProgress: progressSpy,
     });
 
     instance.get('/foo');
 
     getAjaxRequest().then(function (request) {
-      expect(request.eventBus.eventList.progress.length).toEqual(2);
+      request.respondWith({
+        status: 200,
+        responseText: '{"foo": "bar"}'
+      });
+      expect(progressSpy).toHaveBeenCalled();
       done();
     });
   });
 
   it('should add a upload progress handler from instance config', function (done) {
-    function progressHandler(event) {};
+    var progressSpy = jasmine.createSpy('progress');
 
     var instance = axios.create({
-      progressUpload: progressHandler,
+      onUploadProgress: progressSpy,
     });
 
     instance.get('/foo');
 
     getAjaxRequest().then(function (request) {
-      // Jasmine-Ajax fake XHR upload events are broken, so for now just test that nothing breaks/crashes
-      // expect(request.upload.eventBus.eventList.progress.length).toEqual(2);
+      // expect(progressSpy).toHaveBeenCalled();
       done();
     });
   });
 
   it('should add upload and download progress handlers from instance config', function (done) {
-    function progressHandler(event) {};
+    var downloadProgressSpy = jasmine.createSpy('downloadProgress');
+    var uploadProgressSpy = jasmine.createSpy('uploadProgress');
 
     var instance = axios.create({
-      progressDownload: progressHandler,
-      progressUpload: progressHandler,
+      onDownloadProgress: downloadProgressSpy,
+      onUploadProgress: uploadProgressSpy,
     });
 
     instance.get('/foo');
 
     getAjaxRequest().then(function (request) {
-      // Jasmine-Ajax fake XHR upload events are broken, so for now just test that nothing breaks/crashes
-      // expect(request.upload.eventBus.eventList.progress.length).toEqual(2);
+      // expect(uploadProgressSpy).toHaveBeenCalled();
+      expect(downloadProgressSpy).not.toHaveBeenCalled();
+      request.respondWith({
+        status: 200,
+        responseText: '{"foo": "bar"}'
+      });
+      expect(downloadProgressSpy).toHaveBeenCalled();
+      done();
       done();
     });
   });

--- a/test/specs/progress.spec.js
+++ b/test/specs/progress.spec.js
@@ -1,0 +1,94 @@
+describe('progress events', function () {
+  beforeEach(function () {
+    jasmine.Ajax.install();
+  });
+
+  afterEach(function () {
+    jasmine.Ajax.uninstall();
+  });
+
+  it('should add a download progress handler', function (done) {
+    function progressHandler(event) {};
+
+    axios('/foo', { progressDownload: progressHandler } );
+
+    getAjaxRequest().then(function (request) {
+      // Not sure of the best way to test this, so just test that the new listener is present
+      expect(request.eventBus.eventList.progress.length).toEqual(2);
+      done();
+    });
+  });
+
+  it('should add a upload progress handler', function (done) {
+    function progressHandler(event) {};
+
+    axios('/foo', { progressUpload: progressHandler } );
+
+    getAjaxRequest().then(function (request) {
+      // Jasmine-Ajax fake XHR upload events are broken, so for now just test that nothing breaks/crashes
+      // expect(request.upload.eventBus.eventList.progress.length).toEqual(2);
+      done();
+    });
+  });
+
+  it('should add both upload and download progress handlers', function (done) {
+    function progressHandler(event) {};
+
+    axios('/foo', { progressDownload: progressHandler, progressUpload: progressHandler });
+
+    getAjaxRequest().then(function (request) {
+      expect(request.eventBus.eventList.progress.length).toEqual(2);
+      // Jasmine-Ajax fake XHR upload events are broken, so for now just test that nothing breaks/crashes
+      // expect(request.upload.eventBus.eventList.progress.length).toEqual(2);
+      done();
+    });
+  });
+
+  it('should add a download progress handler from instance config', function (done) {
+    function progressHandler(event) {};
+
+    var instance = axios.create({
+      progressDownload: progressHandler,
+    });
+
+    instance.get('/foo');
+
+    getAjaxRequest().then(function (request) {
+      expect(request.eventBus.eventList.progress.length).toEqual(2);
+      done();
+    });
+  });
+
+  it('should add a upload progress handler from instance config', function (done) {
+    function progressHandler(event) {};
+
+    var instance = axios.create({
+      progressUpload: progressHandler,
+    });
+
+    instance.get('/foo');
+
+    getAjaxRequest().then(function (request) {
+      // Jasmine-Ajax fake XHR upload events are broken, so for now just test that nothing breaks/crashes
+      // expect(request.upload.eventBus.eventList.progress.length).toEqual(2);
+      done();
+    });
+  });
+
+  it('should add upload and download progress handlers from instance config', function (done) {
+    function progressHandler(event) {};
+
+    var instance = axios.create({
+      progressDownload: progressHandler,
+      progressUpload: progressHandler,
+    });
+
+    instance.get('/foo');
+
+    getAjaxRequest().then(function (request) {
+      // Jasmine-Ajax fake XHR upload events are broken, so for now just test that nothing breaks/crashes
+      // expect(request.upload.eventBus.eventList.progress.length).toEqual(2);
+      done();
+    });
+  });
+});

--- a/test/specs/progress.spec.js
+++ b/test/specs/progress.spec.js
@@ -1,4 +1,4 @@
-fdescribe('progress events', function () {
+describe('progress events', function () {
   beforeEach(function () {
     jasmine.Ajax.install();
   });


### PR DESCRIPTION
Splits progress config into two options, `progressDownload` and `progressUpload`. No longer limits these to `GET`/`POST`/`PUT` requests.

Previously there were no tests for progress handling...so i've added some. But testing is difficult as the Jasmine-AJAX plugin doesn't handle `xhr.upload.addEventListener` correctly. Im also not overly familiar with Jasmine and it's tools so if you have any ideas on how i could improve the tests please let me know :) 

At some point in future i'll do a PR to allow progress events in the Node world.