### PR TITLE
Add OPTIONS-method as a shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ For convenience aliases have been provided for all supported request methods.
 ##### axios.get(url[, config])
 ##### axios.delete(url[, config])
 ##### axios.head(url[, config])
+##### axios.options(url[, config])
 ##### axios.post(url[, data[, config]])
 ##### axios.put(url[, data[, config]])
 ##### axios.patch(url[, data[, config]])
-##### axios.options(url[, data[, config]])
 
 ###### NOTE
 When using the alias methods `url`, `method`, and `data` properties don't need to be specified in config.
@@ -176,6 +176,7 @@ The available instance methods are listed below. The specified config will be me
 ##### axios#get(url[, config])
 ##### axios#delete(url[, config])
 ##### axios#head(url[, config])
+##### axios#options(url[, config])
 ##### axios#post(url[, data[, config]])
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ For convenience aliases have been provided for all supported request methods.
 ##### axios.post(url[, data[, config]])
 ##### axios.put(url[, data[, config]])
 ##### axios.patch(url[, data[, config]])
+##### axios.options(url[, data[, config]])
 
 ###### NOTE
 When using the alias methods `url`, `method`, and `data` properties don't need to be specified in config.

--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -61,7 +61,7 @@ Axios.prototype.request = function request(config) {
 };
 
 // Provide aliases for supported request methods
-utils.forEach(['delete', 'get', 'head'], function forEachMethodNoData(method) {
+utils.forEach(['delete', 'get', 'head', 'options'], function forEachMethodNoData(method) {
   /*eslint func-names:0*/
   Axios.prototype[method] = function(url, config) {
     return this.request(utils.merge(config || {}, {

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -3,6 +3,7 @@ describe('static api', function () {
     expect(typeof axios.request).toEqual('function');
     expect(typeof axios.get).toEqual('function');
     expect(typeof axios.head).toEqual('function');
+    expect(typeof axios.options).toEqual('function');
     expect(typeof axios.delete).toEqual('function');
     expect(typeof axios.post).toEqual('function');
     expect(typeof axios.put).toEqual('function');
@@ -42,6 +43,7 @@ describe('instance api', function () {
   it('should have request methods', function () {
     expect(typeof instance.request).toEqual('function');
     expect(typeof instance.get).toEqual('function');
+    expect(typeof instance.options).toEqual('function');
     expect(typeof instance.head).toEqual('function');
     expect(typeof instance.delete).toEqual('function');
     expect(typeof instance.post).toEqual('function');


### PR DESCRIPTION
Axios is missing OPTIONS-method as a shortcut. This PR will implement it
