### PR TITLE
Fix proxy bugs

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -94,6 +94,8 @@ module.exports = function httpAdapter(config) {
 
     if (proxy) {
       options.host = proxy.host;
+      options.hostname = proxy.host;
+      options.headers.host = parsed.hostname;
       options.port = proxy.port;
       options.path = parsed.protocol + '//' + parsed.hostname + (parsed.port ? ':' + parsed.port : '') + options.path;
     }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -95,7 +95,7 @@ module.exports = function httpAdapter(config) {
     if (proxy) {
       options.host = proxy.host;
       options.hostname = proxy.host;
-      options.headers.host = parsed.hostname;
+      options.headers.host = parsed.hostname + (parsed.port ? ':' + parsed.port : '');
       options.port = proxy.port;
       options.path = parsed.protocol + '//' + parsed.hostname + (parsed.port ? ':' + parsed.port : '') + options.path;
     }


### PR DESCRIPTION
This should fix two issues related to using the proxy options.

* [Hostname is preferred over host](https://nodejs.org/api/http.html#http_http_request_options_callback)
* Adds the accompanying [host header](https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-9.4) to the correct url