### PR TITLE
remove PROTECTION_PREFIX support

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,7 +3,6 @@
 var utils = require('./utils');
 var normalizeHeaderName = require('./helpers/normalizeHeaderName');
 
-var PROTECTION_PREFIX = /^\)\]\}',?\n/;
 var DEFAULT_CONTENT_TYPE = {
   'Content-Type': 'application/x-www-form-urlencoded'
 };
@@ -56,7 +55,6 @@ var defaults = {
   transformResponse: [function transformResponse(data) {
     /*eslint no-param-reassign:0*/
     if (typeof data === 'string') {
-      data = data.replace(PROTECTION_PREFIX, '');
       try {
         data = JSON.parse(data);
       } catch (e) { /* Ignore */ }


### PR DESCRIPTION
As discussed in #555 - this is no longer relevant as a default behavior and removing it saves some CPU cycles and potentially some memory allocations too.
