### PR TITLE
replace literal regex syntax

### DIFF
--- a/lib/helpers/isAbsoluteURL.js
+++ b/lib/helpers/isAbsoluteURL.js
@@ -10,5 +10,5 @@ module.exports = function isAbsoluteURL(url) {
   // A URL is considered absolute if it begins with "<scheme>://" or "//" (protocol-relative URL).
   // RFC 3986 defines scheme name as a sequence of characters beginning with a letter and followed
   // by any combination of letters, digits, plus, period, or hyphen.
-  return /^([a-z][a-z\d\+\-\.]*:)?\/\//i.test(url);
+  return new RegExp('/^([a-z][a-z\d\+\-\.]*:)?\/\//i').test(url);
 };


### PR DESCRIPTION
The CMS i'm using uses JSMin to minify assets. It interprets the two forward slashes before `i.test(url);` in the RegExp literal as a comment and removes the function call, causing a syntax error. Using the RegExp constructor prevents this from happening.