### PR TITLE
Fix upload progress event example

### DIFF
--- a/examples/upload/index.html
+++ b/examples/upload/index.html
@@ -28,7 +28,7 @@
 
           var config = {
             onUploadProgress: function(progressEvent) {
-              var percentCompleted = progressEvent.loaded / progressEvent.total;
+              var percentCompleted = Math.round( (progressEvent.loaded * 100) / progressEvent.total );
             }
           };
 


### PR DESCRIPTION
The original example always returns 1, this fix returns the numbers correctly.

https://github.com/mzabriskie/axios/blob/master/examples/upload/index.html#L31