### PR TITLE
Fixing combineURLs to support an empty relativeURL

### DIFF
--- a/lib/helpers/combineURLs.js
+++ b/lib/helpers/combineURLs.js
@@ -8,5 +8,8 @@
  * @returns {string} The combined URL
  */
 module.exports = function combineURLs(baseURL, relativeURL) {
-  return baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '');
+  var end = relativeURL.replace(/^\/+/, '');
+  return end
+    ? baseURL.replace(/\/+$/, '') + '/' + end
+    : baseURL;
 };

--- a/lib/helpers/combineURLs.js
+++ b/lib/helpers/combineURLs.js
@@ -8,8 +8,7 @@
  * @returns {string} The combined URL
  */
 module.exports = function combineURLs(baseURL, relativeURL) {
-  var end = relativeURL.replace(/^\/+/, '');
-  return end
-    ? baseURL.replace(/\/+$/, '') + '/' + end
+  return relativeURL
+    ? baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '')
     : baseURL;
 };

--- a/test/specs/helpers/combineURLs.spec.js
+++ b/test/specs/helpers/combineURLs.spec.js
@@ -12,4 +12,8 @@ describe('helpers::combineURLs', function () {
   it('should insert missing slash', function () {
     expect(combineURLs('https://api.github.com', 'users')).toBe('https://api.github.com/users');
   });
+
+  it('should not insert slash when relative url missing/empty', function () {
+    expect(combineURLs('https://api.github.com/users', '')).toBe('https://api.github.com/users');
+  });
 });

--- a/test/specs/helpers/combineURLs.spec.js
+++ b/test/specs/helpers/combineURLs.spec.js
@@ -16,4 +16,8 @@ describe('helpers::combineURLs', function () {
   it('should not insert slash when relative url missing/empty', function () {
     expect(combineURLs('https://api.github.com/users', '')).toBe('https://api.github.com/users');
   });
+
+  it('should allow a single slash for relative url', function () {
+    expect(combineURLs('https://api.github.com/users', '/')).toBe('https://api.github.com/users/');
+  });
 });


### PR DESCRIPTION
Ending slashes were always being appended to the baseURL, regardless of if the relative URL had length.

By making sure that we're supporting empty relative urls, and not appending extraneous slashes to the base url, support for absolute API endpoints becomes possible.

Added a single test spec. 📈 

Closes #574