### PR TITLE
Removed custom typings for the Promise-interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,12 +58,6 @@ export interface AxiosError extends Error {
   response?: AxiosResponse;
 }
 
-export interface Promise<V> {
-  then<R1, R2>(onFulfilled: (value: V) => R1 | Promise<R1>, onRejected: (error: any) => R2 | Promise<R2>): Promise<R1 | R2>;
-  then<R>(onFulfilled: (value: V) => R | Promise<R>): Promise<R>;
-  catch<R>(onRejected: (error: any) => R | Promise<R>): Promise<R>;
-}
-
 export interface AxiosPromise extends Promise<AxiosResponse> {
 }
 


### PR DESCRIPTION
It differs from the standard Promise-interface that comes with TypeScript, making it incompatible with other uses of promises.

If targeting ES5 or lower, then you can add "es2015.promise" to the "lib" option of your tsconfig.json file to include support for ES2015 promises.