### PR TITLE
Fix IE8 to be determined as a standard browser

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -181,7 +181,7 @@ function isStandardBrowserEnv() {
   return (
     typeof window !== 'undefined' &&
     typeof document !== 'undefined' &&
-    typeof document.createElement === 'function'
+    typeof document.createElement === 'undefined'
   );
 }
 


### PR DESCRIPTION
In IE8, the value of `typeof document.createElemen` is `object`, not `function` so this `isStandardBrowserEnv` returns `false`. Because of this wrong determine, CORS is not working in IE8.