### PR TITLE
Fix bug with isStandardBrowserEnv (#597)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -181,7 +181,7 @@ function isStandardBrowserEnv() {
   return (
     typeof window !== 'undefined' &&
     typeof document !== 'undefined' &&
-    typeof document.createElement === 'function'
+    typeof document.createElement !== 'undefined'
   );
 }
 

--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -51,6 +51,7 @@ describe('requests', function () {
       expect(reason.config.method).toBe('get');
       expect(reason.config.url).toBe('http://thisisnotaserver');
 
+      jasmine.Ajax.install();
       done();
     };
 


### PR DESCRIPTION
`document.createElement` is not function in Internet Explorer 8.
But isStandardBrowserEnv checks standard browser environment like below.

```javascript
function isStandardBrowserEnv() {
  return (
    typeof window !== 'undefined' &&
    typeof document !== 'undefined' &&
    typeof document.createElement !== 'function'
  );
}
```

As I mentioned above, `document.createElement` is not function(is object) in Internet Explorer 8, so isStandardBrowserEnv determine wrong; and XDomainRequest is not working in IE8.