### PR TITLE
Fixing condition of suppressing DOMException caused by XHR Level 2 Incompatible Browsers

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -137,7 +137,7 @@ module.exports = function xhrAdapter(config) {
       try {
         request.responseType = config.responseType;
       } catch (e) {
-        // Expectes DOMException thrown by browsers not compatible XMLHttpRequest Level 2.
+        // Expected DOMException thrown by browsers not compatible XMLHttpRequest Level 2.
         // But, this can be suppressed for 'json' type as it can be parsed by default 'transformResponse' function.
         if (config.responseType !== 'json') {
           throw e;

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -137,7 +137,9 @@ module.exports = function xhrAdapter(config) {
       try {
         request.responseType = config.responseType;
       } catch (e) {
-        if (request.responseType !== 'json') {
+        // Expectes DOMException thrown by browsers not compatible XMLHttpRequest Level 2.
+        // But, this can be suppressed for 'json' type as it can be parsed by default 'transformResponse' function.
+        if (config.responseType !== 'json') {
           throw e;
         }
       }


### PR DESCRIPTION
If I'm not mistaken, the author of this code block intended to check `config.responseType`, not `request.resposeType` . 

It's clear that the error is failure in assigning value to  ` request.responseType `, so checking `request.responseType` inside the catch block seems pointless.

With the current version, specifying` responseType: 'json' ` causes legacy browsers (imcompatible with XHR Level 2) to throw DOMException 12.