### PR TITLE
Enable writings node.js buffers directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ These are the available config options for making requests. Only the `url` is re
 
   // `transformRequest` allows changes to the request data before it is sent to the server
   // This is only applicable for request methods 'PUT', 'POST', and 'PATCH'
-  // The last function in the array must return a string, an ArrayBuffer, or a Stream
+  // The last function in the array must return a string, a Node.js Buffer, an ArrayBuffer, or a Stream
   transformRequest: [function (data) {
     // Do whatever you want to transform the data
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -32,6 +32,8 @@ module.exports = function httpAdapter(config) {
     if (data && !utils.isStream(data)) {
       if (utils.isArrayBuffer(data)) {
         data = new Buffer(new Uint8Array(data));
+      } else if (Buffer.isBuffer(data)) {
+        // data is already a buffer
       } else if (utils.isString(data)) {
         data = new Buffer(data, 'utf-8');
       } else {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
   },
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "1.0.0"
+    "follow-redirects": "0.0.7"
   }
 }


### PR DESCRIPTION
Hi there,

I ran into encoding problems with binary request string data (gzipped payloads) being transformed via Buffer.toString('utf8') in transformRequest.

This PR will enable passing in node buffers directly instead of needing to create a stream or copy to an ArrayBuffer just for the sake of sending compressed data.