### PR TITLE
Adding a way to disable all proxy processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,7 @@ These are the available config options for making requests. Only the `url` is re
   httpsAgent: new https.Agent({ keepAlive: true }),
 
   // 'proxy' defines the hostname and port of the proxy server
-  // On node the proxy can also come from the 'http_proxy' environment variable.
-  // Use false to disable all proxy handling.
+  // Use `false` to disable proxies, ignoring environment variables.
   // `auth` indicates that HTTP Basic auth should be used to connect to the proxy, and
   // supplies credentials.
   // This will set an `Proxy-Authorization` header, overwriting any existing

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ These are the available config options for making requests. Only the `url` is re
   httpsAgent: new https.Agent({ keepAlive: true }),
 
   // 'proxy' defines the hostname and port of the proxy server
+  // On node the proxy can also come from the 'http_proxy' environment variable.
+  // Use false to disable all proxy handling.
   // `auth` indicates that HTTP Basic auth should be used to connect to the proxy, and
   // supplies credentials.
   // This will set an `Proxy-Authorization` header, overwriting any existing

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -84,7 +84,7 @@ module.exports = function httpAdapter(config) {
     };
 
     var proxy = config.proxy;
-    if (!proxy) {
+    if (!proxy && proxy !== false) {
       var proxyEnv = protocol.slice(0, -1) + '_proxy';
       var proxyUrl = process.env[proxyEnv] || process.env[proxyEnv.toUpperCase()];
       if (proxyUrl) {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -311,6 +311,23 @@ module.exports = {
     });
   },
 
+  testHTTPProxyDisabled: function(test) {
+    // set the env variable
+    process.env.http_proxy = 'http://does-not-exists.example.com:4242/';
+
+    server = http.createServer(function(req, res) {
+      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
+      res.end('123456789');
+    }).listen(4444, function() {
+      axios.get('http://localhost:4444/', {
+          proxy: false
+        }).then(function(res) {
+          test.equal(res.data, '123456789', 'should not pass through proxy');
+          test.done();
+        });
+    });
+  },
+
   testHTTPProxyEnv: function(test) {
     server = http.createServer(function(req, res) {
       res.setHeader('Content-Type', 'text/html; charset=UTF-8');


### PR DESCRIPTION
When the proxy field in configuration is === false all proxy processing is disabled. This specifically disable the 'http_proxy' environment variable handling.

It should fix #635 and possibly #434 too (That issue suggest 2 different solutions, the other being already in PR #565).
PR #565 is complementary to this one as it add handling of the `no_proxy` environment variable.

I created this PR to fix https://github.com/ionide/ionide-vscode-fsharp/issues/272