### PR TITLE
Updating transformRequest documentation to include FormData

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ These are the available config options for making requests. Only the `url` is re
 
   // `transformRequest` allows changes to the request data before it is sent to the server
   // This is only applicable for request methods 'PUT', 'POST', and 'PATCH'
-  // The last function in the array must return a string, an ArrayBuffer, or a Stream
+  // The last function in the array must return a string, an ArrayBuffer, FormData, or a Stream
   transformRequest: [function (data) {
     // Do whatever you want to transform the data
 


### PR DESCRIPTION
Tested in browsers, I am able to use `transformRequest` to return a `FormData` instance and it works as expected.

However, the documentation seems to indicate this functionality is *not* supported, so this updates it to include.

May want to indicate Browser only vs. Node only for stream