### PR TITLE
Axios should be export with "="

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,4 +128,4 @@ export interface AxiosStatic extends AxiosInstance {
 
 declare const Axios: AxiosStatic;
 
-export default Axios;
+export = Axios;


### PR DESCRIPTION
because of axios still use `module.exports=` for exporting package.
we should use `export = Axios` 

see more https://github.com/Microsoft/TypeScript/issues/5565