### PR TITLE
TypeScript generic AxiosResponse type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,10 @@ export interface AxiosResponse {
   config: AxiosRequestConfig;
 }
 
+export interface GenericAxiosResponse<R> extends AxiosResponse {
+  data: R;
+}
+
 export interface AxiosError extends Error {
   config: AxiosRequestConfig;
   code?: string;


### PR DESCRIPTION
First of all thanks for this great library moreover with TypeScript definitions.

I want to generate REST client class using [typescript-generator](https://github.com/vojtechhabarta/typescript-generator). Generated methods will have structure similar to this example:
``` typescript
getPerson(personId: number): AxiosPromise {
    return axios.request({ method: "GET", url: `api/people/${personId}` });
}
```
unfortunately this doesn't provide response with typed `data` property although it could.

So instead of `AxiosPromise` or `Promise<AxiosResponse>` I would like to return `Promise<AxiosResponse<Person>>` in this case.

I guess it is not good to "generify" existing `AxiosResponse` (it could break some user code) so I created `GenericAxiosResponse<R>` type.