### PR TITLE
Proper detection of react-native in isStandardBrowserEnv function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -169,19 +169,22 @@ function trim(str) {
  *
  * This allows axios to run in a web worker, and react-native.
  * Both environments support XMLHttpRequest, but not fully standard globals.
+ * As of react-native 0.13, it can be identified from navigator.product.
  *
  * web workers:
  *  typeof window -> undefined
  *  typeof document -> undefined
  *
  * react-native:
- *  typeof document.createElement -> undefined
+ *  navigator.product -> 'ReactNative'
  */
 function isStandardBrowserEnv() {
+  if (typeof navigator.product !== 'undefined' && navigator.product === 'ReactNative') {
+    return false;
+  }
   return (
     typeof window !== 'undefined' &&
-    typeof document !== 'undefined' &&
-    typeof document.createElement === 'function'
+    typeof document !== 'undefined'
   );
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -169,7 +169,6 @@ function trim(str) {
  *
  * This allows axios to run in a web worker, and react-native.
  * Both environments support XMLHttpRequest, but not fully standard globals.
- * As of react-native 0.13, it can be identified from navigator.product.
  *
  * web workers:
  *  typeof window -> undefined
@@ -179,7 +178,7 @@ function trim(str) {
  *  navigator.product -> 'ReactNative'
  */
 function isStandardBrowserEnv() {
-  if (typeof navigator.product !== 'undefined' && navigator.product === 'ReactNative') {
+  if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
     return false;
   }
   return (


### PR DESCRIPTION
Detecting react native from navigator object, fixes issues #597 - for IE8 and #728 when other react-native libraries uses document like react-native-signalr in:
[https://github.com/zaach/react-native-signalr/blob/master/src/bridge.js](url) 