### PR TITLE
support node buffers less than 8192 bytes

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -30,13 +30,15 @@ module.exports = function httpAdapter(config) {
     }
 
     if (data && !utils.isStream(data)) {
-      if (utils.isArrayBuffer(data)) {
+      if (utils.isBuffer(data)) {
+        // Nothing to do...
+      } else if (utils.isArrayBuffer(data)) {
         data = new Buffer(new Uint8Array(data));
       } else if (utils.isString(data)) {
         data = new Buffer(data, 'utf-8');
       } else {
         return reject(createError(
-          'Data after transformation must be a string, an ArrayBuffer, or a Stream',
+          'Data after transformation must be a string, an ArrayBuffer, a Buffer, or a Stream',
           config
         ));
       }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -32,6 +32,7 @@ var defaults = {
     normalizeHeaderName(headers, 'Content-Type');
     if (utils.isFormData(data) ||
       utils.isArrayBuffer(data) ||
+      utils.isBuffer(data) ||
       utils.isStream(data) ||
       utils.isFile(data) ||
       utils.isBlob(data)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,16 @@ function isArray(val) {
 }
 
 /**
+ * Determine if a value is a Node Buffer
+ *
+ * @param {Object} val The value to test
+ * @returns {boolean} True if value is a Node Buffer, otherwise false
+ */
+function isBuffer(val) {
+  return ((typeof Buffer !== 'undefined') && (Buffer.isBuffer) && (Buffer.isBuffer(val)));
+}
+
+/**
  * Determine if a value is an ArrayBuffer
  *
  * @param {Object} val The value to test
@@ -281,6 +291,7 @@ function extend(a, b, thisArg) {
 module.exports = {
   isArray: isArray,
   isArrayBuffer: isArrayBuffer,
+  isBuffer: isBuffer,
   isFormData: isFormData,
   isArrayBufferView: isArrayBufferView,
   isString: isString,


### PR DESCRIPTION
Node unsafe Buffers less than Buffer.poolSize (8192 bytes) are not handled correctly by Axios. This adds support to pass Node buffers untouched.