### PR TITLE
Adding comment about header names are lower cased

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ The response for a request contains the following information.
   statusText: 'OK',
 
   // `headers` the headers that the server responded with
+  // All header names are lower cased
   headers: {},
 
   // `config` is the config that was provided to `axios` for the request


### PR DESCRIPTION
Header names are lower cased by axios Which make sense since the header names are case insensitive. This should be mentioned in the README