### PR TITLE
Add `auth.bearer` shorthand

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -70,7 +70,7 @@ module.exports = function httpAdapter(config) {
     }
 
     if (bearer) {
-      headers.Authorization = 'Bearer ' + bearer;
+      headers.Authorization = 'Bearer ' + typeof bearer === 'function' ? bearer() : bearer;
     } else if (auth) {
       delete headers.Authorization;
     }

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -45,26 +45,33 @@ module.exports = function httpAdapter(config) {
       headers['Content-Length'] = data.length;
     }
 
-    // HTTP basic authentication
+    // HTTP authentication
     var auth = undefined;
+    var bearer = undefined;
     if (config.auth) {
-      var username = config.auth.username || '';
-      var password = config.auth.password || '';
-      auth = username + ':' + password;
+      if (config.auth.bearer) {
+        bearer = config.auth.bearer;
+      } else {
+        var username = config.auth.username || '';
+        var password = config.auth.password || '';
+        auth = username + ':' + password;
+      }
     }
 
     // Parse url
     var parsed = url.parse(config.url);
     var protocol = parsed.protocol || 'http:';
 
-    if (!auth && parsed.auth) {
+    if (!auth && !bearer && parsed.auth) {
       var urlAuth = parsed.auth.split(':');
       var urlUsername = urlAuth[0] || '';
       var urlPassword = urlAuth[1] || '';
       auth = urlUsername + ':' + urlPassword;
     }
 
-    if (auth) {
+    if (bearer) {
+      headers.Authorization = 'Bearer ' + bearer;
+    } else if (auth) {
       delete headers.Authorization;
     }
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -70,7 +70,7 @@ module.exports = function httpAdapter(config) {
     }
 
     if (bearer) {
-      headers.Authorization = 'Bearer ' + typeof bearer === 'function' ? bearer() : bearer;
+      headers.Authorization = 'Bearer ' + (typeof bearer === 'function' ? bearer() : bearer);
     } else if (auth) {
       delete headers.Authorization;
     }

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -37,7 +37,7 @@ module.exports = function xhrAdapter(config) {
 
     // HTTP authentication
     if (config.auth) {
-      var bearer = config.auth.bearer
+      var bearer = config.auth.bearer;
       if (bearer) {
         requestHeaders.Authorization = 'Bearer ' + (typeof bearer === 'function' ? bearer() : bearer);
       } else {

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -39,7 +39,7 @@ module.exports = function xhrAdapter(config) {
     if (config.auth) {
       var bearer = config.auth.bearer
       if (bearer) {
-        requestHeaders.Authorization = 'Bearer ' + typeof bearer === 'function' ? bearer() : bearer;
+        requestHeaders.Authorization = 'Bearer ' + (typeof bearer === 'function' ? bearer() : bearer);
       } else {
         var username = config.auth.username || '';
         var password = config.auth.password || '';

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -35,7 +35,7 @@ module.exports = function xhrAdapter(config) {
       request.ontimeout = function handleTimeout() {};
     }
 
-    // HTTP basic authentication
+    // HTTP authentication
     if (config.auth) {
       if (config.auth.bearer) {
         requestHeaders.Authorization = 'Bearer ' + config.auth.bearer;

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -37,8 +37,9 @@ module.exports = function xhrAdapter(config) {
 
     // HTTP authentication
     if (config.auth) {
-      if (config.auth.bearer) {
-        requestHeaders.Authorization = 'Bearer ' + config.auth.bearer;
+      var bearer = config.auth.bearer
+      if (bearer) {
+        requestHeaders.Authorization = 'Bearer ' + typeof bearer === 'function' ? bearer() : bearer;
       } else {
         var username = config.auth.username || '';
         var password = config.auth.password || '';

--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -37,9 +37,13 @@ module.exports = function xhrAdapter(config) {
 
     // HTTP basic authentication
     if (config.auth) {
-      var username = config.auth.username || '';
-      var password = config.auth.password || '';
-      requestHeaders.Authorization = 'Basic ' + btoa(username + ':' + password);
+      if (config.auth.bearer) {
+        requestHeaders.Authorization = 'Bearer ' + config.auth.bearer;
+      } else {
+        var username = config.auth.username || '';
+        var password = config.auth.password || '';
+        requestHeaders.Authorization = 'Basic ' + btoa(username + ':' + password);
+      }
     }
 
     request.open(config.method.toUpperCase(), buildURL(config.url, config.params, config.paramsSerializer), true);


### PR DESCRIPTION
Makes it easier to use JWTs and such by avoiding manual string concatenation in user code to set `Authorization: Bearer <TOKEN>` request header:

```js
axios.get('https://api.example.com/something', {
  auth: {
    bearer: localStorage.get('token')
  }
})
```

Also allow `auth.bearer` to be a function in case your tokens expire/change frequently:

```js
const api = axios.create({
  baseURL: 'https://api.example.com',
  auth: {
    bearer: () => localStorage.get('token')
  }
});

api.get('/something')
```