### PR TITLE
Return the last request made in axios response

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,12 @@ The response for a request contains the following information.
   headers: {},
 
   // `config` is the config that was provided to `axios` for the request
-  config: {}
+  config: {},
+
+  // `request` is the request that generated this response
+  // It is the last ClientRequest instance in node.js (in redirects)
+  // and an XMLHttpRequest instance the browser
+  request: {}
 }
 ```
 

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -149,12 +149,15 @@ module.exports = function httpAdapter(config) {
         break;
       }
 
+      // return the last request in case of redirects
+      var lastRequest = res.req || req;
+
       var response = {
         status: res.statusCode,
         statusText: res.statusMessage,
         headers: res.headers,
         config: config,
-        request: req
+        request: lastRequest
       };
 
       if (config.responseType === 'stream') {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -83,6 +83,7 @@ module.exports = {
     }).listen(4444, function () {
       axios.get('http://localhost:4444/one').then(function (res) {
         test.equal(res.data, str);
+        test.equal(res.request.path, '/two');
         test.done();
       });
     });


### PR DESCRIPTION
This PR modifies the request included in axios responses to use the last one made by the follow-redirects modules.

Example:

```
// example.com/foo redirects to example.com/bar
axios.get('http://example.com/foo').then((response) => {
  response.request.path === '/bar';
});

It also documents the feature in the README.md.