### PR TITLE
Update follow-redirects dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
   },
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "1.2.3"
+    "follow-redirects": "^1.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
   },
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "1.0.0"
+    "follow-redirects": "1.2.3"
   }
 }


### PR DESCRIPTION
Using the follow-redirects 1.0.0 causes [this reported write after end issue](https://github.com/olalonde/follow-redirects/issues/50) which was also mentioned in [this axios PR](https://github.com/mzabriskie/axios/pull/680). It looks like the problem with follow-redirects [was fixed in 1.1.0](https://github.com/olalonde/follow-redirects/commit/9eec6f0fb8d1c51dbd9be732ce1e2c794a01b652) but if axios is going to update the dependency it might as well update to the latest version now.