### PR TITLE
No buffer in browser

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -10,7 +10,6 @@ var httpsFollow = require('follow-redirects').https;
 var url = require('url');
 var zlib = require('zlib');
 var pkg = require('./../../package.json');
-var Buffer = require('buffer').Buffer;
 var createError = require('../core/createError');
 var enhanceError = require('../core/enhanceError');
 
@@ -30,7 +29,7 @@ module.exports = function httpAdapter(config) {
     }
 
     if (data && !utils.isStream(data)) {
-      if (utils.isBuffer(data)) {
+      if (Buffer.isBuffer(data)) {
         // Nothing to do...
       } else if (utils.isArrayBuffer(data)) {
         data = new Buffer(new Uint8Array(data));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var bind = require('./helpers/bind');
+var isBuffer = require('is-buffer');
 
 /*global toString:true*/
 
@@ -16,16 +17,6 @@ var toString = Object.prototype.toString;
  */
 function isArray(val) {
   return toString.call(val) === '[object Array]';
-}
-
-/**
- * Determine if a value is a Node Buffer
- *
- * @param {Object} val The value to test
- * @returns {boolean} True if value is a Node Buffer, otherwise false
- */
-function isBuffer(val) {
-  return ((typeof Buffer !== 'undefined') && (Buffer.isBuffer) && (Buffer.isBuffer(val)));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "typings": "./index.d.ts",
   "dependencies": {
-    "follow-redirects": "^1.2.3"
+    "follow-redirects": "^1.2.3",
+    "is-buffer": "^1.1.5"
   }
 }


### PR DESCRIPTION
This PR fixes #846 by using Feross' [is-buffer](https://github.com/feross/is-buffer) module instead `Buffer.isBuffer()`.
