### PR TITLE
Limit the request method type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export interface AxiosProxyConfig {
 
 export interface AxiosRequestConfig {
   url?: string;
-  method?: string;
+  method?: 'get'|'delete'|'head'|'post'|'put'|'patch';
   baseURL?: string;
   transformRequest?: AxiosTransformer | AxiosTransformer[];
   transformResponse?: AxiosTransformer | AxiosTransformer[];


### PR DESCRIPTION
breaking change: Before this change the uppercase form of each method works as well as the lowercase. This change will cause typescript compiler errors for users that chose to use the upper case form.
