### PR TITLE
Fixing error on Cancel

### DIFF
--- a/lib/cancel/Cancel.js
+++ b/lib/cancel/Cancel.js
@@ -8,12 +8,13 @@
  */
 function Cancel(message) {
   this.message = message;
+  this.__CANCEL__ = true;
 }
+
+Cancel.prototype = Error.prototype;
 
 Cancel.prototype.toString = function toString() {
   return 'Cancel' + (this.message ? ': ' + this.message : '');
 };
-
-Cancel.prototype.__CANCEL__ = true;
 
 module.exports = Cancel;


### PR DESCRIPTION
When using Axios along with Bluebird, requests cancellations has a warning:
```
Warning: a promise was rejected with a non-error: [object Object]
```

The PR makes Axios throw a true custom error on request cancellation.