### PR TITLE
Convert the method parameter to lowercase

### DIFF
--- a/lib/core/Axios.js
+++ b/lib/core/Axios.js
@@ -35,6 +35,7 @@ Axios.prototype.request = function request(config) {
   }
 
   config = utils.merge(defaults, this.defaults, { method: 'get' }, config);
+  config.method = config.method.toLowerCase();
 
   // Support baseURL config
   if (config.baseURL && !isAbsoluteURL(config.url)) {

--- a/test/specs/requests.spec.js
+++ b/test/specs/requests.spec.js
@@ -17,6 +17,22 @@ describe('requests', function () {
     });
   });
 
+  it('should treat method value as lowercase string', function (done) {
+    axios({
+      url: '/foo',
+      method: 'POST'
+    }).then(function (response) {
+      expect(response.config.method).toBe('post');
+      done();
+    });
+
+    getAjaxRequest().then(function (request) {
+      request.respondWith({
+        status: 200
+      });
+    });
+  });
+
   it('should allow string arg as url, and config arg', function (done) {
     axios.post('/foo');
 


### PR DESCRIPTION
In some cases, passing Request Method in uppercase causes some errors.

Example:

axios.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';

return axios({
  method: 'POST',
  url: url
});

https://github.com/mzabriskie/axios/pull/912