### PR TITLE
refactor(http): use ClientRequest "aborted" value

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -19,7 +19,6 @@ module.exports = function httpAdapter(config) {
     var data = config.data;
     var headers = config.headers;
     var timer;
-    var aborted = false;
 
     // Set User-Agent (required by some servers)
     // Only set header if it hasn't been set in config
@@ -129,7 +128,7 @@ module.exports = function httpAdapter(config) {
 
     // Create the request
     var req = transport.request(options, function handleResponse(res) {
-      if (aborted) return;
+      if (req.aborted) return;
 
       // Response has been received so kill timer that handles request timeout
       clearTimeout(timer);
@@ -177,7 +176,7 @@ module.exports = function httpAdapter(config) {
         });
 
         stream.on('error', function handleStreamError(err) {
-          if (aborted) return;
+          if (req.aborted) return;
           reject(enhanceError(err, config, null, lastRequest));
         });
 
@@ -195,7 +194,7 @@ module.exports = function httpAdapter(config) {
 
     // Handle errors
     req.on('error', function handleRequestError(err) {
-      if (aborted) return;
+      if (req.aborted) return;
       reject(enhanceError(err, config, null, req));
     });
 
@@ -204,20 +203,16 @@ module.exports = function httpAdapter(config) {
       timer = setTimeout(function handleRequestTimeout() {
         req.abort();
         reject(createError('timeout of ' + config.timeout + 'ms exceeded', config, 'ECONNABORTED', req));
-        aborted = true;
       }, config.timeout);
     }
 
     if (config.cancelToken) {
       // Handle cancellation
       config.cancelToken.promise.then(function onCanceled(cancel) {
-        if (aborted) {
-          return;
-        }
+        if (req.aborted) return;
 
         req.abort();
         reject(cancel);
-        aborted = true;
       });
     }
 


### PR DESCRIPTION
The [ClientRequest](https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_class_http_clientrequest) has an "[aborted](https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_request_aborted)" key having a value of the timestamp of when the request was aborted or which is `undefined` otherwise.

This PR aims to remove the unnecessary local `aborted` variable.

This is also safer because users could choose to manually abort the request, and currently it would not be taken into account immediately.

Do I miss something here?
