### PR TITLE
Use XMLHttpRequest in IE10+ instead of XDomainRequest

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -24,7 +24,8 @@ module.exports = function xhrAdapter(config) {
     // For IE 8/9 CORS support
     // Only supports POST and GET calls and doesn't returns the response headers.
     // DON'T do this for testing b/c XMLHttpRequest is mocked, not XDomainRequest.
-    if (process.env.NODE_ENV !== 'test' &&
+    if (!window.XMLHttpRequest &&
+        process.env.NODE_ENV !== 'test' &&
         typeof window !== 'undefined' &&
         window.XDomainRequest && !('withCredentials' in request) &&
         !isURLSameOrigin(config.url)) {


### PR DESCRIPTION
For IE10+ it is prefered to use XMLHttpRequest instead of XDomainRequest, as XDomainRequest is deprecated and may cause problems with some IE11 versions (https://blogs.msdn.microsoft.com/ieinternals/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds/).

This solution proposes to use XMLHttpRequest whenever is possible.