### PR TITLE
Add bundlesize to test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Promise based HTTP client for the browser and node.js",
   "main": "index.js",
   "scripts": {
-    "test": "grunt test",
+    "test": "grunt test && bundlesize",
     "start": "node ./sandbox/server.js",
     "build": "NODE_ENV=production grunt build",
     "preversion": "npm test",
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/mzabriskie/axios",
   "devDependencies": {
+    "bundlesize": "^0.5.7",
     "coveralls": "^2.11.9",
     "es6-promise": "^4.0.5",
     "grunt": "^1.0.1",
@@ -74,5 +75,11 @@
   "dependencies": {
     "follow-redirects": "^1.2.3",
     "is-buffer": "^1.1.5"
-  }
+  },
+  "bundlesize": [
+    {
+      "path": "./dist/axios.min.js",
+      "threshold": "5kB"
+    }
+  ]
 }


### PR DESCRIPTION
**What**:

Basically this in the terminal and CI logs: 

```
PASS  ./dist/axios.min.js: 4.45kB < threshold 5kB gzip 
```

And this on the build status:

<img src="https://raw.githubusercontent.com/siddharthkp/bundlesize/master/art/status.png" width="500px"/>

**Why**:

This will help in **keeping** the library tiny.

Would prevent things like [issues#846](https://github.com/mzabriskie/axios/issues/846) from happening

**How**:

1. Added [bundlesize](https://github.com/siddharthkp/bundlesize) as a dev dependency
2. Added `bundlesize` in `npm test`

There is a tiny bit of configuration needed:

1. Setting the file and threshold:

    The config sits inside `package.json`, the threshold is set to 5kB right now.

2. Authorize bundlesize:

    `bundlesize` needs access to github API with scope `repo:status`, You can follow the [steps here](https://github.com/siddharthkp/bundlesize/blob/master/README.md#build-status)
