### PR TITLE
Updating Typescript typing for AxiosError to include `request?` param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,7 @@ export interface AxiosResponse {
 export interface AxiosError extends Error {
   config: AxiosRequestConfig;
   code?: string;
+  request?: any;
   response?: AxiosResponse;
 }
 


### PR DESCRIPTION
I made the type `any`. It looks like the actual type is generally `XMLHttpRequest`, but I'm not sure that that's true in all cases. Would be happy to change that if advised otherwise.
    
ref https://github.com/mzabriskie/axios/issues/1014