### PR TITLE
Fix - Multiple instances creation

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -4,6 +4,7 @@ var utils = require('./utils');
 var bind = require('./helpers/bind');
 var Axios = require('./core/Axios');
 var defaults = require('./defaults');
+var cloneDeep = require('lodash.clonedeep');
 
 /**
  * Create an instance of Axios
@@ -32,7 +33,7 @@ axios.Axios = Axios;
 
 // Factory for creating new instances
 axios.create = function create(instanceConfig) {
-  return createInstance(utils.merge(defaults, instanceConfig));
+  return createInstance(utils.merge(cloneDeep(defaults), instanceConfig));
 };
 
 // Expose Cancel & CancelToken

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "typings": "./index.d.ts",
   "dependencies": {
     "follow-redirects": "^1.2.3",
-    "is-buffer": "^1.1.5"
+    "is-buffer": "^1.1.5",
+    "lodash.clonedeep": "^4.5.0"
   }
 }


### PR DESCRIPTION
Related to #1009

#### Description :

When a new instance of axios is created yet, the `defaults` object containing the default configuration is merged with the provided `instanceConfig`. Sadly, this merge is not deeply performed which results in a reference copy of all the values that are plain objects in `defaults`. This sometimes results in a definitely not expected behavior (See #1009 for demonstration).

#### Proposal :

Instead of using the original object, a deep copy of `defaults` should be created before merging on instance creation, which avoids any collisions between instances.