### PR TITLE
Fixing Typescript declaration for incorrect export style

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+declare namespace Axios {
+
 export interface AxiosTransformer {
   (data: any): any;
 }
@@ -121,6 +123,8 @@ export interface AxiosStatic extends AxiosInstance {
   spread<T, R>(callback: (...args: T[]) => R): (array: T[]) => R;
 }
 
-declare const Axios: AxiosStatic;
+}
 
-export default Axios;
+declare const Axios: Axios.AxiosStatic;
+
+export = Axios;


### PR DESCRIPTION
ES style module export declaration should not be used until
stuffes actually exported in ES module way. Otherwise typescript
compiler would expect either `default` member is presented if we
do `import axios from 'axios'` or `import * as axios 'axios'`, in
either way, neither the code is emit correctly nor code would pass
type checking.

This commit fix such issue and typescript will emit code correctly
for both import style.

